### PR TITLE
Community forum: share, browse & load custom transit networks

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,36 +1,61 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# TransitFlow
+
+GO Transit network design and simulation in the browser — live GTFS, one map, four modes.
+
+## Tech Stack
+
+**Framework & Language**
+- [Next.js 16](https://nextjs.org) (App Router, Turbopack)
+- [React 19](https://react.dev)
+- [TypeScript](https://www.typescriptlang.org)
+
+**Mapping**
+- [Mapbox GL JS](https://docs.mapbox.com/mapbox-gl-js/) — interactive map
+- [Mapbox Static Images API](https://docs.mapbox.com/api/maps/static-images/) — server-side map previews
+- [@mapbox/mapbox-gl-draw](https://github.com/mapbox/mapbox-gl-draw) — freehand route drawing
+
+**Styling & UI**
+- [Tailwind CSS v4](https://tailwindcss.com)
+- [shadcn/ui](https://ui.shadcn.com) — component library
+- [Base UI](https://base-ui.com) — headless primitives
+- [Lucide React](https://lucide.dev) — icons
+
+**Auth**
+- [NextAuth v5 (Auth.js)](https://authjs.dev) — GitHub & Google OAuth, JWT sessions
+
+**Database**
+- [Neon Postgres](https://neon.tech) — serverless PostgreSQL
+- [Drizzle ORM](https://orm.drizzle.team) — schema, queries, migrations
+- [@neondatabase/serverless](https://github.com/neondatabase/serverless) — HTTP driver
+
+**AI**
+- [Anthropic Claude API](https://docs.anthropic.com) — route agent & schedule optimiser (`claude-sonnet-4-6`)
+
+**Data**
+- [GTFS](https://gtfs.org) — real GO Transit schedule data (pre-computed + live)
+
+**Deployment**
+- [Vercel](https://vercel.com) — hosting, preview deployments, environment variables
 
 ## Getting Started
 
-First, run the development server:
-
 ```bash
+cd client
+npm install
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000).
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+Copy `.env.example` to `.env.local` and fill in the required keys:
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+```
+NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=
+MAPBOX_ACCESS_TOKEN=
+AUTH_SECRET=
+AUTH_GITHUB_ID=
+AUTH_GITHUB_SECRET=
+AUTH_GOOGLE_ID=
+AUTH_GOOGLE_SECRET=
+DATABASE_URL=
+```

--- a/client/app/api/auth/[...nextauth]/route.ts
+++ b/client/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from "@/lib/auth";
+
+export const { GET, POST } = handlers;

--- a/client/app/api/community/posts/[id]/comments/route.ts
+++ b/client/app/api/community/posts/[id]/comments/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db, comments, users, posts } from "@/lib/db";
+import { upsertUser } from "@/lib/upsertUser";
+import { eq, asc } from "drizzle-orm";
+
+// ── GET /api/community/posts/[id]/comments — public ──────────────────────────
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: postId } = await params;
+
+    const rows = await db
+      .select({
+        id: comments.id,
+        body: comments.body,
+        createdAt: comments.createdAt,
+        userId: comments.userId,
+        userName: users.name,
+        userAvatar: users.avatarUrl,
+        userLogin: users.githubLogin,
+      })
+      .from(comments)
+      .innerJoin(users, eq(comments.userId, users.id))
+      .where(eq(comments.postId, postId))
+      .orderBy(asc(comments.createdAt));
+
+    return NextResponse.json({
+      comments: rows.map((r) => ({
+        id: r.id,
+        body: r.body,
+        createdAt: r.createdAt,
+        user: {
+          id: r.userId,
+          name: r.userName,
+          avatarUrl: r.userAvatar,
+          githubLogin: r.userLogin,
+        },
+      })),
+    });
+  } catch (err) {
+    console.error("[community/comments GET]", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+// ── POST /api/community/posts/[id]/comments — auth required ──────────────────
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: postId } = await params;
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json() as { body?: string };
+    const text = body?.body?.trim();
+
+    if (!text || text.length === 0) {
+      return NextResponse.json({ error: "Comment body is required" }, { status: 400 });
+    }
+    if (text.length > 2000) {
+      return NextResponse.json({ error: "Comment must be 2000 characters or less" }, { status: 400 });
+    }
+
+    await upsertUser(session);
+
+    const [comment] = await db
+      .insert(comments)
+      .values({ postId, userId: session.user.id, body: text })
+      .returning({
+        id: comments.id,
+        body: comments.body,
+        createdAt: comments.createdAt,
+      });
+
+    const user = session.user as typeof session.user & { login?: string };
+
+    return NextResponse.json(
+      {
+        comment: {
+          ...comment,
+          user: {
+            id: session.user.id,
+            name: session.user.name ?? null,
+            avatarUrl: session.user.image ?? null,
+            githubLogin: user.login ?? null,
+          },
+        },
+      },
+      { status: 201 }
+    );
+  } catch (err) {
+    console.error("[community/comments POST]", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/client/app/api/community/posts/[id]/likes/route.ts
+++ b/client/app/api/community/posts/[id]/likes/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db, posts, likes, users } from "@/lib/db";
+import { upsertUser } from "@/lib/upsertUser";
+import { eq, and, count } from "drizzle-orm";
+
+// ── GET /api/community/posts/[id]/likes — is current user liked? ─────────────
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: postId } = await params;
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ liked: false });
+    }
+
+    const [row] = await db
+      .select({ postId: likes.postId })
+      .from(likes)
+      .where(and(eq(likes.postId, postId), eq(likes.userId, session.user.id)))
+      .limit(1);
+
+    return NextResponse.json({ liked: !!row });
+  } catch (err) {
+    console.error("[community/likes GET]", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+// ── POST /api/community/posts/[id]/likes — toggle like ───────────────────────
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: postId } = await params;
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    await upsertUser(session);
+
+    // Check if already liked
+    const [existing] = await db
+      .select({ postId: likes.postId })
+      .from(likes)
+      .where(and(eq(likes.postId, postId), eq(likes.userId, session.user.id)))
+      .limit(1);
+
+    let liked: boolean;
+
+    if (existing) {
+      // Unlike
+      await db
+        .delete(likes)
+        .where(and(eq(likes.postId, postId), eq(likes.userId, session.user.id)));
+      liked = false;
+    } else {
+      // Like
+      await db.insert(likes).values({ postId, userId: session.user.id });
+      liked = true;
+    }
+
+    // Recalculate denormalized count
+    const [{ newCount }] = await db
+      .select({ newCount: count() })
+      .from(likes)
+      .where(eq(likes.postId, postId));
+
+    await db
+      .update(posts)
+      .set({ likesCount: newCount })
+      .where(eq(posts.id, postId));
+
+    return NextResponse.json({ liked, likesCount: newCount });
+  } catch (err) {
+    console.error("[community/likes POST]", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/client/app/api/community/posts/[id]/route.ts
+++ b/client/app/api/community/posts/[id]/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db, posts, users, comments } from "@/lib/db";
+import { eq, asc } from "drizzle-orm";
+
+// ── GET /api/community/posts/[id] — public, returns full post + route_data ───
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+
+    const [row] = await db
+      .select({
+        id: posts.id,
+        title: posts.title,
+        description: posts.description,
+        routeData: posts.routeData,
+        stopCount: posts.stopCount,
+        routeType: posts.routeType,
+        color: posts.color,
+        likesCount: posts.likesCount,
+        createdAt: posts.createdAt,
+        userId: posts.userId,
+        userName: users.name,
+        userAvatar: users.avatarUrl,
+        userLogin: users.githubLogin,
+      })
+      .from(posts)
+      .innerJoin(users, eq(posts.userId, users.id))
+      .where(eq(posts.id, id))
+      .limit(1);
+
+    if (!row) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      post: {
+        id: row.id,
+        title: row.title,
+        description: row.description,
+        routeData: row.routeData,
+        stopCount: row.stopCount,
+        routeType: row.routeType,
+        color: row.color,
+        likesCount: row.likesCount,
+        createdAt: row.createdAt,
+        user: {
+          id: row.userId,
+          name: row.userName,
+          avatarUrl: row.userAvatar,
+          githubLogin: row.userLogin,
+        },
+      },
+    });
+  } catch (err) {
+    console.error("[community/posts/[id] GET]", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/client/app/api/community/posts/route.ts
+++ b/client/app/api/community/posts/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db, posts, users, likes } from "@/lib/db";
+import { upsertUser } from "@/lib/upsertUser";
+import { desc, eq, sql, count } from "drizzle-orm";
+import type { CustomRoute } from "@/lib/gtfs";
+
+const PAGE_SIZE = 20;
+
+// ── GET /api/community/posts — public paginated feed ─────────────────────────
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = req.nextUrl;
+    const page = Math.max(1, Number(searchParams.get("page") ?? 1));
+    const sort = searchParams.get("sort") === "top" ? "top" : "recent";
+    const offset = (page - 1) * PAGE_SIZE;
+
+    const orderBy =
+      sort === "top"
+        ? desc(posts.likesCount)
+        : desc(posts.createdAt);
+
+    const rows = await db
+      .select({
+        id: posts.id,
+        title: posts.title,
+        description: posts.description,
+        stopCount: posts.stopCount,
+        routeType: posts.routeType,
+        color: posts.color,
+        likesCount: posts.likesCount,
+        createdAt: posts.createdAt,
+        userId: posts.userId,
+        userName: users.name,
+        userAvatar: users.avatarUrl,
+        userLogin: users.githubLogin,
+      })
+      .from(posts)
+      .innerJoin(users, eq(posts.userId, users.id))
+      .orderBy(orderBy)
+      .limit(PAGE_SIZE)
+      .offset(offset);
+
+    const [{ total }] = await db
+      .select({ total: count() })
+      .from(posts);
+
+    const nextPage = offset + PAGE_SIZE < total ? page + 1 : null;
+
+    return NextResponse.json({
+      posts: rows.map((r) => ({
+        id: r.id,
+        title: r.title,
+        description: r.description,
+        stopCount: r.stopCount,
+        routeType: r.routeType,
+        color: r.color,
+        likesCount: r.likesCount,
+        createdAt: r.createdAt,
+        user: {
+          id: r.userId,
+          name: r.userName,
+          avatarUrl: r.userAvatar,
+          githubLogin: r.userLogin,
+        },
+      })),
+      total,
+      nextPage,
+    });
+  } catch (err) {
+    console.error("[community/posts GET]", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+// ── POST /api/community/posts — create a post (auth required) ─────────────────
+export async function POST(req: NextRequest) {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json() as {
+      title?: string;
+      description?: string;
+      routeData?: CustomRoute;
+    };
+
+    const { title, description, routeData } = body;
+
+    if (!title || typeof title !== "string" || title.trim().length === 0) {
+      return NextResponse.json({ error: "Title is required" }, { status: 400 });
+    }
+    if (title.trim().length > 120) {
+      return NextResponse.json({ error: "Title must be 120 characters or less" }, { status: 400 });
+    }
+    if (description && description.length > 1000) {
+      return NextResponse.json({ error: "Description must be 1000 characters or less" }, { status: 400 });
+    }
+    if (!routeData || typeof routeData !== "object") {
+      return NextResponse.json({ error: "routeData is required" }, { status: 400 });
+    }
+
+    await upsertUser(session);
+
+    // Derive stats server-side from the route data
+    const stopCount = Array.isArray(routeData.stops) ? routeData.stops.length : 0;
+    const routeType = routeData.type === "train" ? "train" : "bus";
+    const color = typeof routeData.color === "string" ? routeData.color : "#3b82f6";
+
+    const [post] = await db
+      .insert(posts)
+      .values({
+        userId: session.user.id,
+        title: title.trim(),
+        description: description?.trim() ?? null,
+        routeData: routeData as unknown as Record<string, unknown>,
+        stopCount,
+        routeType,
+        color,
+        likesCount: 0,
+      })
+      .returning({ id: posts.id });
+
+    return NextResponse.json({ post: { id: post.id } }, { status: 201 });
+  } catch (err) {
+    console.error("[community/posts POST]", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/client/app/api/community/posts/route.ts
+++ b/client/app/api/community/posts/route.ts
@@ -4,6 +4,7 @@ import { db, posts, users, likes } from "@/lib/db";
 import { upsertUser } from "@/lib/upsertUser";
 import { desc, eq, sql, count } from "drizzle-orm";
 import type { CustomRoute } from "@/lib/gtfs";
+import { buildStaticMapUrl } from "@/lib/mapboxStaticImage";
 
 const PAGE_SIZE = 20;
 
@@ -30,6 +31,7 @@ export async function GET(req: NextRequest) {
         color: posts.color,
         likesCount: posts.likesCount,
         createdAt: posts.createdAt,
+        routeData: posts.routeData,
         userId: posts.userId,
         userName: users.name,
         userAvatar: users.avatarUrl,
@@ -57,6 +59,7 @@ export async function GET(req: NextRequest) {
         color: r.color,
         likesCount: r.likesCount,
         createdAt: r.createdAt,
+        previewUrl: buildStaticMapUrl(r.routeData as unknown as CustomRoute),
         user: {
           id: r.userId,
           name: r.userName,

--- a/client/app/community/[id]/page.tsx
+++ b/client/app/community/[id]/page.tsx
@@ -1,0 +1,186 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { Map, ArrowLeft, MapPin, Calendar } from "lucide-react";
+import MarketingShell from "@/components/marketing/MarketingShell";
+import MarketingHeader from "@/components/marketing/MarketingHeader";
+import MarketingFooter from "@/components/marketing/MarketingFooter";
+import AuthorAvatar from "@/components/community/AuthorAvatar";
+import RouteTypeBadge from "@/components/community/RouteTypeBadge";
+import MiniRouteMap from "@/components/community/MiniRouteMap";
+import LikeButton from "@/components/community/LikeButton";
+import CommentSection from "@/components/community/CommentSection";
+import { db, posts, users, comments, likes } from "@/lib/db";
+import { eq, asc } from "drizzle-orm";
+import type { CustomRoute } from "@/lib/gtfs";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+async function getPost(id: string) {
+  const [row] = await db
+    .select({
+      id: posts.id,
+      title: posts.title,
+      description: posts.description,
+      routeData: posts.routeData,
+      stopCount: posts.stopCount,
+      routeType: posts.routeType,
+      color: posts.color,
+      likesCount: posts.likesCount,
+      createdAt: posts.createdAt,
+      userId: posts.userId,
+      userName: users.name,
+      userAvatar: users.avatarUrl,
+      userLogin: users.githubLogin,
+    })
+    .from(posts)
+    .innerJoin(users, eq(posts.userId, users.id))
+    .where(eq(posts.id, id))
+    .limit(1);
+
+  return row ?? null;
+}
+
+async function getComments(postId: string) {
+  return db
+    .select({
+      id: comments.id,
+      body: comments.body,
+      createdAt: comments.createdAt,
+      userId: comments.userId,
+      userName: users.name,
+      userAvatar: users.avatarUrl,
+      userLogin: users.githubLogin,
+    })
+    .from(comments)
+    .innerJoin(users, eq(comments.userId, users.id))
+    .where(eq(comments.postId, postId))
+    .orderBy(asc(comments.createdAt));
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { id } = await params;
+  try {
+    const post = await getPost(id);
+    if (!post) return { title: "Not found — TransitFlow Community" };
+    return {
+      title: `${post.title} — TransitFlow Community`,
+      description: post.description ?? `A custom ${post.routeType} route with ${post.stopCount} stops.`,
+    };
+  } catch {
+    return { title: "TransitFlow Community" };
+  }
+}
+
+export default async function CommunityPostPage({ params }: PageProps) {
+  const { id } = await params;
+
+  let post: Awaited<ReturnType<typeof getPost>>;
+  let postComments: Awaited<ReturnType<typeof getComments>>;
+
+  try {
+    [post, postComments] = await Promise.all([getPost(id), getComments(id)]);
+  } catch {
+    notFound();
+  }
+
+  if (!post) notFound();
+
+  const route = post.routeData as unknown as CustomRoute;
+  const date = new Date(post.createdAt).toLocaleDateString("en-CA", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  const formattedComments = postComments.map((c) => ({
+    id: c.id,
+    body: c.body,
+    createdAt: c.createdAt.toISOString(),
+    user: {
+      id: c.userId,
+      name: c.userName,
+      avatarUrl: c.userAvatar,
+      githubLogin: c.userLogin,
+    },
+  }));
+
+  return (
+    <MarketingShell>
+      <MarketingHeader />
+
+      <main className="mx-auto w-full max-w-4xl flex-1 px-5 py-12 lg:px-8 lg:py-16">
+        {/* Back */}
+        <Link
+          href="/community"
+          className="mb-8 inline-flex items-center gap-1.5 text-sm text-[var(--landing-muted)] transition-colors hover:text-[var(--landing-fg)]"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden />
+          Back to community
+        </Link>
+
+        {/* Color strip */}
+        <div className="mb-6 h-1.5 w-full rounded-full" style={{ backgroundColor: post.color }} />
+
+        {/* Post header */}
+        <div className="mb-6 flex flex-col gap-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <RouteTypeBadge type={post.routeType} />
+            <span className="flex items-center gap-1 text-xs text-[var(--landing-muted)]">
+              <MapPin className="h-3 w-3" aria-hidden />
+              {post.stopCount} stop{post.stopCount !== 1 ? "s" : ""}
+            </span>
+            <span className="flex items-center gap-1 text-xs text-[var(--landing-muted)]">
+              <Calendar className="h-3 w-3" aria-hidden />
+              {date}
+            </span>
+          </div>
+
+          <h1 className="text-3xl font-semibold tracking-tight text-[var(--landing-fg)] sm:text-4xl">
+            {post.title}
+          </h1>
+
+          {post.description && (
+            <p className="text-base leading-relaxed text-[var(--landing-muted)]">
+              {post.description}
+            </p>
+          )}
+
+          <AuthorAvatar
+            name={post.userName}
+            avatarUrl={post.userAvatar}
+            githubLogin={post.userLogin}
+            size="md"
+          />
+        </div>
+
+        {/* Mini map */}
+        <div className="mb-6 overflow-hidden rounded-2xl border border-[var(--landing-border)]">
+          <MiniRouteMap route={route} />
+        </div>
+
+        {/* Actions */}
+        <div className="mb-10 flex flex-wrap items-center gap-3">
+          <Link
+            href={`/map?community_route=${post.id}`}
+            className="inline-flex items-center gap-2 rounded-lg bg-[var(--landing-accent)] px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[#006b2d]"
+          >
+            <Map className="h-4 w-4" aria-hidden />
+            Load into map
+          </Link>
+          <LikeButton postId={post.id} initialLikesCount={post.likesCount} />
+        </div>
+
+        {/* Divider */}
+        <hr className="mb-10 border-[var(--landing-border)]" />
+
+        {/* Comments */}
+        <CommentSection postId={post.id} initialComments={formattedComments} />
+      </main>
+
+      <MarketingFooter />
+    </MarketingShell>
+  );
+}

--- a/client/app/community/[id]/page.tsx
+++ b/client/app/community/[id]/page.tsx
@@ -7,7 +7,7 @@ import MarketingHeader from "@/components/marketing/MarketingHeader";
 import MarketingFooter from "@/components/marketing/MarketingFooter";
 import AuthorAvatar from "@/components/community/AuthorAvatar";
 import RouteTypeBadge from "@/components/community/RouteTypeBadge";
-import MiniRouteMap from "@/components/community/MiniRouteMap";
+import CommunityMapPreviewWrapper from "@/components/community/CommunityMapPreviewWrapper";
 import LikeButton from "@/components/community/LikeButton";
 import CommentSection from "@/components/community/CommentSection";
 import { db, posts, users, comments, likes } from "@/lib/db";
@@ -156,9 +156,9 @@ export default async function CommunityPostPage({ params }: PageProps) {
           />
         </div>
 
-        {/* Mini map */}
+        {/* Route map */}
         <div className="mb-6 overflow-hidden rounded-2xl border border-[var(--landing-border)]">
-          <MiniRouteMap route={route} />
+          <CommunityMapPreviewWrapper route={route} />
         </div>
 
         {/* Actions */}

--- a/client/app/community/page.tsx
+++ b/client/app/community/page.tsx
@@ -1,0 +1,113 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight, Users } from "lucide-react";
+import MarketingShell from "@/components/marketing/MarketingShell";
+import MarketingHeader from "@/components/marketing/MarketingHeader";
+import MarketingFooter from "@/components/marketing/MarketingFooter";
+import CommunityFeed from "@/components/community/CommunityFeed";
+import type { PostSummary } from "@/components/community/PostCard";
+import { db, posts, users } from "@/lib/db";
+import { desc, eq, count } from "drizzle-orm";
+
+export const metadata: Metadata = {
+  title: "Community — TransitFlow",
+  description:
+    "Browse and share custom GO Transit network designs from the TransitFlow community.",
+};
+
+const PAGE_SIZE = 20;
+
+async function getInitialPosts(): Promise<{
+  posts: PostSummary[];
+  nextPage: number | null;
+}> {
+  try {
+    const rows = await db
+      .select({
+        id: posts.id,
+        title: posts.title,
+        description: posts.description,
+        stopCount: posts.stopCount,
+        routeType: posts.routeType,
+        color: posts.color,
+        likesCount: posts.likesCount,
+        createdAt: posts.createdAt,
+        userId: posts.userId,
+        userName: users.name,
+        userAvatar: users.avatarUrl,
+        userLogin: users.githubLogin,
+      })
+      .from(posts)
+      .innerJoin(users, eq(posts.userId, users.id))
+      .orderBy(desc(posts.createdAt))
+      .limit(PAGE_SIZE);
+
+    const [{ total }] = await db.select({ total: count() }).from(posts);
+    const nextPage = PAGE_SIZE < total ? 2 : null;
+
+    return {
+      posts: rows.map((r) => ({
+        id: r.id,
+        title: r.title,
+        description: r.description,
+        stopCount: r.stopCount,
+        routeType: r.routeType,
+        color: r.color,
+        likesCount: r.likesCount,
+        createdAt: r.createdAt,
+        user: {
+          id: r.userId,
+          name: r.userName,
+          avatarUrl: r.userAvatar,
+          githubLogin: r.userLogin,
+        },
+      })),
+      nextPage,
+    };
+  } catch {
+    // DB not yet configured — return empty state
+    return { posts: [], nextPage: null };
+  }
+}
+
+export default async function CommunityPage() {
+  const { posts: initialPosts, nextPage } = await getInitialPosts();
+
+  return (
+    <MarketingShell>
+      <MarketingHeader />
+
+      <main className="mx-auto w-full max-w-6xl flex-1 px-5 py-12 lg:px-8 lg:py-16">
+        {/* Header */}
+        <div className="mb-10 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <div className="mb-2 flex items-center gap-2">
+              <Users className="h-5 w-5 text-[var(--landing-accent)]" aria-hidden />
+              <p className="text-xs font-semibold uppercase tracking-widest text-[var(--landing-accent)]">
+                Community
+              </p>
+            </div>
+            <h1 className="text-3xl font-semibold tracking-tight text-[var(--landing-fg)] sm:text-4xl">
+              Shared networks
+            </h1>
+            <p className="mt-2 text-base text-[var(--landing-muted)]">
+              Browse custom GO Transit designs from the community. Click any card to explore the route.
+            </p>
+          </div>
+
+          <Link
+            href="/map"
+            className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-[var(--landing-accent)] px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[#006b2d]"
+          >
+            Design a route
+            <ArrowRight className="h-4 w-4" aria-hidden />
+          </Link>
+        </div>
+
+        <CommunityFeed initialPosts={initialPosts} initialNextPage={nextPage} />
+      </main>
+
+      <MarketingFooter />
+    </MarketingShell>
+  );
+}

--- a/client/app/community/page.tsx
+++ b/client/app/community/page.tsx
@@ -8,6 +8,8 @@ import CommunityFeed from "@/components/community/CommunityFeed";
 import type { PostSummary } from "@/components/community/PostCard";
 import { db, posts, users } from "@/lib/db";
 import { desc, eq, count } from "drizzle-orm";
+import { buildStaticMapUrl } from "@/lib/mapboxStaticImage";
+import type { CustomRoute } from "@/lib/gtfs";
 
 export const metadata: Metadata = {
   title: "Community — TransitFlow",
@@ -32,6 +34,7 @@ async function getInitialPosts(): Promise<{
         color: posts.color,
         likesCount: posts.likesCount,
         createdAt: posts.createdAt,
+        routeData: posts.routeData,
         userId: posts.userId,
         userName: users.name,
         userAvatar: users.avatarUrl,
@@ -55,6 +58,7 @@ async function getInitialPosts(): Promise<{
         color: r.color,
         likesCount: r.likesCount,
         createdAt: r.createdAt,
+        previewUrl: buildStaticMapUrl(r.routeData as unknown as CustomRoute),
         user: {
           id: r.userId,
           name: r.userName,

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Toaster } from "sonner";
+import { SessionProvider } from "next-auth/react";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -33,8 +34,10 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">
-        {children}
-        <Toaster richColors closeButton position="top-right" />
+        <SessionProvider>
+          {children}
+          <Toaster richColors closeButton position="top-right" />
+        </SessionProvider>
       </body>
     </html>
   );

--- a/client/app/map/page.tsx
+++ b/client/app/map/page.tsx
@@ -117,6 +117,14 @@ function MapPageContent() {
   const [hoveredRoute, setHoveredRoute] = useState<{ shortName: string; variantId: string } | null>(null);
   const [clickedRoute, setClickedRoute] = useState<ClickedRoute | null>(null);
   const [shareTarget, setShareTarget] = useState<CustomRoute | null>(null);
+  const [sharePickerOpen, setSharePickerOpen] = useState(false);
+  // Close share picker on outside click
+  useEffect(() => {
+    if (!sharePickerOpen) return;
+    const handler = () => setSharePickerOpen(false);
+    window.addEventListener("click", handler, { capture: true, once: true });
+    return () => window.removeEventListener("click", handler, { capture: true });
+  }, [sharePickerOpen]);
   const [isDrawing, setIsDrawing] = useState(false);
   const [drawnGeometry, setDrawnGeometry] = useState<[number, number][] | null>(null);
   const [editingRoute, setEditingRoute] = useState<CustomRoute | undefined>();
@@ -990,14 +998,49 @@ function MapPageContent() {
             <Pencil className="w-3.5 h-3.5 text-slate-400" />
             {customRoutes.length} saved route{customRoutes.length !== 1 ? "s" : ""}
           </button>
-          <button
-            onClick={() => setShareTarget(customRoutes[customRoutes.length - 1])}
-            className="bg-[#007A33] backdrop-blur-xl rounded-xl border border-[#007A33] shadow-md px-3 py-2 text-xs font-semibold text-white flex items-center gap-1.5 hover:bg-[#005f28] hover:shadow-lg transition-all"
-            title="Share your latest route to the community"
-          >
-            <Share2 className="w-3.5 h-3.5" />
-            Share
-          </button>
+          <div className="relative">
+            <button
+              onClick={() => {
+                if (customRoutes.length === 1) {
+                  setShareTarget(customRoutes[0]);
+                } else {
+                  setSharePickerOpen((o) => !o);
+                }
+              }}
+              className="bg-[#007A33] backdrop-blur-xl rounded-xl border border-[#007A33] shadow-md px-3 py-2 text-xs font-semibold text-white flex items-center gap-1.5 hover:bg-[#005f28] hover:shadow-lg transition-all"
+            >
+              <Share2 className="w-3.5 h-3.5" />
+              Share
+            </button>
+            {sharePickerOpen && (
+              <div className="absolute bottom-full right-0 mb-2 w-56 rounded-xl border border-slate-200 bg-white shadow-xl overflow-hidden z-30">
+                <p className="px-3 py-2 text-[10px] font-semibold uppercase tracking-wide text-slate-400 border-b border-slate-100">
+                  Pick a route to share
+                </p>
+                <ul>
+                  {customRoutes.map((r) => (
+                    <li key={r.id}>
+                      <button
+                        className="flex w-full items-center gap-2.5 px-3 py-2 text-left text-xs font-medium text-slate-800 hover:bg-slate-50 transition-colors"
+                        onClick={() => {
+                          setShareTarget(r);
+                          setSharePickerOpen(false);
+                        }}
+                      >
+                        <span
+                          className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[9px] font-bold text-white"
+                          style={{ backgroundColor: r.color }}
+                        >
+                          {r.type === "train" ? "R" : "B"}
+                        </span>
+                        <span className="truncate">{r.name || "Custom route"}</span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
         </div>
       )}
 

--- a/client/app/map/page.tsx
+++ b/client/app/map/page.tsx
@@ -255,14 +255,6 @@ function MapPageContent() {
     setMode(m);
   }, [searchParams]);
 
-  useEffect(() => {
-    const m = searchParams.get("mode");
-    if (m !== "simulate") return;
-    const t = window.setTimeout(() => sim.loadSimulation(), 500);
-    return () => window.clearTimeout(t);
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- snapshot sim.loadSimulation; sim identity churns
-  }, [searchParams]);
-
   // ── Design tab + Extend seed when build is committed in URL ───────────────
   useEffect(() => {
     if (searchParams.get("mode") !== "build") {
@@ -945,6 +937,7 @@ function MapPageContent() {
           playing={sim.playing}
           speed={sim.speed}
           loading={sim.loading}
+          hasEverLoaded={sim.hasEverLoaded}
           error={sim.error}
           selectedRoutes={sim.selectedRoutes}
           customRoutes={customRoutes}

--- a/client/app/map/page.tsx
+++ b/client/app/map/page.tsx
@@ -827,6 +827,10 @@ function MapPageContent() {
                 routeFilters={routeFilters}
                 onRouteFilterChange={handleRouteFilterChange}
                 onDeleteCustomRoute={requestDeleteCustomRoute}
+                onShareCustomRoute={(id) => {
+                  const route = customRoutes.find((r) => r.id === id);
+                  if (route) setShareTarget(route);
+                }}
               />
             )}
             {mode === "build" && (

--- a/client/app/map/page.tsx
+++ b/client/app/map/page.tsx
@@ -7,6 +7,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import mapboxgl from "mapbox-gl";
 import { Train, Map as MapIcon, PlayCircle, Pencil, CalendarClock } from "lucide-react";
 import { toast } from "sonner";
+import { v4 as uuidv4 } from "uuid";
 import { MapHandle } from "@/components/Map";
 import BrowsePanel from "@/components/panels/BrowsePanel";
 import DesignPanel, { type DesignTab } from "@/components/panels/DesignPanel";
@@ -14,6 +15,7 @@ import ScheduleModal from "@/components/panels/ScheduleModal";
 import SimulationHUD from "@/components/panels/SimulationHUD";
 import RouteTooltip from "@/components/overlays/RouteTooltip";
 import RouteInfoCard from "@/components/overlays/RouteInfoCard";
+import ShareModal from "@/components/community/ShareModal";
 import VehicleInfoPopup from "@/components/overlays/VehicleInfoPopup";
 import DrawGuide from "@/components/overlays/DrawGuide";
 import OpenRailwayMapOverlayControls from "@/components/overlays/OpenRailwayMapOverlayControls";
@@ -114,6 +116,7 @@ function MapPageContent() {
   const [mapLoaded, setMapLoaded] = useState(false);
   const [hoveredRoute, setHoveredRoute] = useState<{ shortName: string; variantId: string } | null>(null);
   const [clickedRoute, setClickedRoute] = useState<ClickedRoute | null>(null);
+  const [shareTarget, setShareTarget] = useState<CustomRoute | null>(null);
   const [isDrawing, setIsDrawing] = useState(false);
   const [drawnGeometry, setDrawnGeometry] = useState<[number, number][] | null>(null);
   const [editingRoute, setEditingRoute] = useState<CustomRoute | undefined>();
@@ -170,6 +173,32 @@ function MapPageContent() {
     [pathname, router, searchParams]
   );
 
+
+  // Import a shared community route when ?community_route=<id> is present
+  useEffect(() => {
+    const communityRouteId = searchParams.get("community_route");
+    if (!communityRouteId) return;
+
+    fetch(`/api/community/posts/${communityRouteId}`)
+      .then((r) => r.json())
+      .then((data: { post?: { routeData?: CustomRoute; title?: string } }) => {
+        const routeData = data.post?.routeData;
+        if (!routeData) return;
+        const importedRoute: CustomRoute = {
+          ...routeData,
+          id: uuidv4(),
+          createdAt: new Date().toISOString(),
+        };
+        saveRoute(importedRoute);
+        toast.success(`"${data.post?.title ?? importedRoute.name}" loaded into your routes`);
+        patchSearch({ community_route: null });
+      })
+      .catch(() => {
+        toast.error("Could not load the shared route");
+        patchSearch({ community_route: null });
+      });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // First visit to bare /map: open Explore + network entry. After user dismisses a mode, do not snap back.
   useEffect(() => {
@@ -876,6 +905,10 @@ function MapPageContent() {
           deleteLabel={clickedRoute.isCustom ? "Delete route" : undefined}
           placement={mode === "simulate" ? "top-left" : "bottom-center"}
           onDelete={clickedRoute.isCustom ? handleDeleteFromCard : undefined}
+          onShare={clickedRoute.isCustom ? () => {
+            const route = customRoutes.find((r) => r.id === clickedRoute.variantId);
+            if (route) setShareTarget(route);
+          } : undefined}
           onClose={() => {
             setClickedRoute(null);
             mapRef.current?.setRouteHighlight(null);
@@ -962,6 +995,9 @@ function MapPageContent() {
           </button>
         </div>
       )}
+
+      {/* Share to community modal */}
+      <ShareModal route={shareTarget} onClose={() => setShareTarget(null)} />
     </div>
   );
 }

--- a/client/app/map/page.tsx
+++ b/client/app/map/page.tsx
@@ -5,7 +5,7 @@ import dynamic from "next/dynamic";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import mapboxgl from "mapbox-gl";
-import { Train, Map as MapIcon, PlayCircle, Pencil, CalendarClock } from "lucide-react";
+import { Train, Map as MapIcon, PlayCircle, Pencil, CalendarClock, Share2 } from "lucide-react";
 import { toast } from "sonner";
 import { v4 as uuidv4 } from "uuid";
 import { MapHandle } from "@/components/Map";
@@ -975,7 +975,7 @@ function MapPageContent() {
       {customRoutes.length > 0
         && !panelOpen
         && mode !== "simulate" && (
-        <div className="absolute bottom-20 right-4 z-20">
+        <div className="absolute bottom-20 right-4 z-20 flex items-center gap-2">
           <button
             onClick={() => {
               patchSearch({
@@ -989,6 +989,14 @@ function MapPageContent() {
           >
             <Pencil className="w-3.5 h-3.5 text-slate-400" />
             {customRoutes.length} saved route{customRoutes.length !== 1 ? "s" : ""}
+          </button>
+          <button
+            onClick={() => setShareTarget(customRoutes[customRoutes.length - 1])}
+            className="bg-[#007A33] backdrop-blur-xl rounded-xl border border-[#007A33] shadow-md px-3 py-2 text-xs font-semibold text-white flex items-center gap-1.5 hover:bg-[#005f28] hover:shadow-lg transition-all"
+            title="Share your latest route to the community"
+          >
+            <Share2 className="w-3.5 h-3.5" />
+            Share
           </button>
         </div>
       )}

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -225,6 +225,34 @@ export default function LandingPage() {
         </div>
       </section>
 
+      {/* Community CTA */}
+      <section className="border-b border-[var(--landing-border)] bg-[var(--landing-elevated)] py-16 sm:py-24">
+        <div className="mx-auto max-w-6xl px-5 lg:px-8">
+          <div className="flex flex-col gap-8 sm:flex-row sm:items-center sm:justify-between">
+            <div className="max-w-xl">
+              <p className="text-xs font-semibold uppercase tracking-widest text-[var(--landing-accent)]">
+                Community
+              </p>
+              <h2 className="mt-2 text-3xl font-semibold tracking-tight text-[var(--landing-fg)] sm:text-4xl">
+                Share your network.{" "}
+                <span className="text-[var(--landing-muted)]">Load others&apos; ideas.</span>
+              </h2>
+              <p className="mt-4 text-base leading-relaxed text-[var(--landing-muted)]">
+                Post your custom routes publicly so anyone can explore them. One click loads any shared
+                network into your own map.
+              </p>
+            </div>
+            <Link
+              href="/community"
+              className="inline-flex shrink-0 items-center gap-2 rounded-xl bg-[var(--landing-accent)] px-6 py-3.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[#006b2d]"
+            >
+              Browse the community
+              <ArrowRight className="h-4 w-4" aria-hidden />
+            </Link>
+          </div>
+        </div>
+      </section>
+
       <MarketingFaq />
 
       <section className="border-b border-white/10 bg-[var(--landing-fg)] py-16 text-[var(--landing-bg)] sm:py-24">

--- a/client/components/community/AuthorAvatar.tsx
+++ b/client/components/community/AuthorAvatar.tsx
@@ -1,0 +1,44 @@
+import Image from "next/image";
+
+interface AuthorAvatarProps {
+  name: string | null;
+  avatarUrl: string | null;
+  githubLogin: string | null;
+  size?: "sm" | "md";
+}
+
+export default function AuthorAvatar({
+  name,
+  avatarUrl,
+  githubLogin,
+  size = "sm",
+}: AuthorAvatarProps) {
+  const dimension = size === "sm" ? 24 : 32;
+  const display = name ?? githubLogin ?? "Anonymous";
+  const initials = display.slice(0, 2).toUpperCase();
+
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      {avatarUrl ? (
+        <Image
+          src={avatarUrl}
+          alt={display}
+          width={dimension}
+          height={dimension}
+          className="rounded-full"
+          unoptimized
+        />
+      ) : (
+        <span
+          className="inline-flex items-center justify-center rounded-full bg-[var(--landing-band)] text-[var(--landing-fg)] font-semibold"
+          style={{ width: dimension, height: dimension, fontSize: dimension * 0.38 }}
+        >
+          {initials}
+        </span>
+      )}
+      <span className="text-sm text-[var(--landing-muted)]">
+        {githubLogin ?? name ?? "Anonymous"}
+      </span>
+    </span>
+  );
+}

--- a/client/components/community/CommentSection.tsx
+++ b/client/components/community/CommentSection.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useState } from "react";
+import { useSession, signIn } from "next-auth/react";
+import { Send, Loader2 } from "lucide-react";
+import AuthorAvatar from "./AuthorAvatar";
+
+interface CommentUser {
+  id: string;
+  name: string | null;
+  avatarUrl: string | null;
+  githubLogin: string | null;
+}
+
+interface Comment {
+  id: string;
+  body: string;
+  createdAt: string | Date;
+  user: CommentUser;
+}
+
+interface CommentSectionProps {
+  postId: string;
+  initialComments: Comment[];
+}
+
+export default function CommentSection({ postId, initialComments }: CommentSectionProps) {
+  const { data: session, status } = useSession();
+  const [comments, setComments] = useState<Comment[]>(initialComments);
+  const [body, setBody] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!body.trim() || submitting) return;
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/community/posts/${postId}/comments`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ body: body.trim() }),
+      });
+      const data = (await res.json()) as { comment?: Comment; error?: string };
+      if (!res.ok) {
+        setError(data.error ?? "Failed to post comment");
+        return;
+      }
+      if (data.comment) {
+        setComments((prev) => [...prev, data.comment!]);
+        setBody("");
+      }
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <h2 className="text-lg font-semibold text-[var(--landing-fg)]">
+        Comments{comments.length > 0 ? ` (${comments.length})` : ""}
+      </h2>
+
+      {/* Comment list */}
+      {comments.length === 0 ? (
+        <p className="text-sm text-[var(--landing-muted)]">
+          No comments yet — be the first!
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-4">
+          {comments.map((c) => (
+            <li
+              key={c.id}
+              className="rounded-xl border border-[var(--landing-border)] bg-[var(--landing-elevated)] p-4"
+            >
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <AuthorAvatar
+                  name={c.user.name}
+                  avatarUrl={c.user.avatarUrl}
+                  githubLogin={c.user.githubLogin}
+                />
+                <time className="text-xs text-[var(--landing-muted)]">
+                  {new Date(c.createdAt).toLocaleDateString("en-CA", {
+                    year: "numeric",
+                    month: "short",
+                    day: "numeric",
+                  })}
+                </time>
+              </div>
+              <p className="text-sm leading-relaxed text-[var(--landing-fg)] whitespace-pre-wrap">
+                {c.body}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Comment form */}
+      {status === "authenticated" ? (
+        <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+          <div className="flex items-start gap-3">
+            <AuthorAvatar
+              name={session.user?.name ?? null}
+              avatarUrl={session.user?.image ?? null}
+              githubLogin={null}
+              size="md"
+            />
+            <textarea
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              placeholder="Add a comment…"
+              maxLength={2000}
+              rows={3}
+              className="flex-1 resize-none rounded-xl border border-[var(--landing-border)] bg-[var(--landing-bg)] px-3 py-2.5 text-sm text-[var(--landing-fg)] placeholder:text-[var(--landing-muted)] outline-none focus:border-[var(--landing-accent)] focus:ring-1 focus:ring-[var(--landing-accent)]"
+            />
+          </div>
+          {error && <p className="text-xs text-red-500">{error}</p>}
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              disabled={!body.trim() || submitting}
+              className="inline-flex items-center gap-2 rounded-lg bg-[var(--landing-accent)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#006b2d] disabled:opacity-50"
+            >
+              {submitting ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Send className="h-4 w-4" aria-hidden />
+              )}
+              Post
+            </button>
+          </div>
+        </form>
+      ) : (
+        <div className="rounded-xl border border-[var(--landing-border)] bg-[var(--landing-band)] p-4 text-center">
+          <p className="text-sm text-[var(--landing-muted)]">
+            Sign in to leave a comment.
+          </p>
+          <button
+            onClick={() => signIn("github")}
+            className="mt-3 inline-flex items-center gap-2 rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-slate-700"
+          >
+            Sign in with GitHub
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/components/community/CommunityFeed.tsx
+++ b/client/components/community/CommunityFeed.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import PostCard, { type PostSummary } from "./PostCard";
+import { Loader2 } from "lucide-react";
+
+interface CommunityFeedProps {
+  initialPosts: PostSummary[];
+  initialNextPage: number | null;
+}
+
+export default function CommunityFeed({
+  initialPosts,
+  initialNextPage,
+}: CommunityFeedProps) {
+  const [sort, setSort] = useState<"recent" | "top">("recent");
+  const [posts, setPosts] = useState<PostSummary[]>(initialPosts);
+  const [nextPage, setNextPage] = useState<number | null>(initialNextPage);
+  const [loading, setLoading] = useState(false);
+
+  const fetchPage = useCallback(
+    async (page: number, newSort: "recent" | "top", replace = false) => {
+      setLoading(true);
+      try {
+        const res = await fetch(
+          `/api/community/posts?page=${page}&sort=${newSort}`
+        );
+        const data = (await res.json()) as {
+          posts: PostSummary[];
+          nextPage: number | null;
+        };
+        setPosts((prev) => (replace ? data.posts : [...prev, ...data.posts]));
+        setNextPage(data.nextPage);
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  const handleSortChange = (newSort: "recent" | "top") => {
+    if (newSort === sort) return;
+    setSort(newSort);
+    fetchPage(1, newSort, true);
+  };
+
+  return (
+    <div>
+      {/* Sort controls */}
+      <div className="mb-6 flex items-center gap-2">
+        {(["recent", "top"] as const).map((s) => (
+          <button
+            key={s}
+            onClick={() => handleSortChange(s)}
+            className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+              sort === s
+                ? "bg-[var(--landing-accent)] text-white"
+                : "border border-[var(--landing-border)] bg-[var(--landing-elevated)] text-[var(--landing-muted)] hover:text-[var(--landing-fg)]"
+            }`}
+          >
+            {s === "recent" ? "Most recent" : "Most liked"}
+          </button>
+        ))}
+      </div>
+
+      {/* Grid */}
+      {posts.length === 0 && !loading ? (
+        <div className="flex flex-col items-center justify-center py-24 text-center">
+          <p className="text-lg font-semibold text-[var(--landing-fg)]">
+            No networks shared yet
+          </p>
+          <p className="mt-2 text-sm text-[var(--landing-muted)]">
+            Be the first — open the map, design a route, and share it.
+          </p>
+        </div>
+      ) : (
+        <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {posts.map((post) => (
+            <li key={post.id}>
+              <PostCard post={post} />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Load more */}
+      {nextPage && (
+        <div className="mt-8 flex justify-center">
+          <button
+            onClick={() => fetchPage(nextPage, sort)}
+            disabled={loading}
+            className="inline-flex items-center gap-2 rounded-lg border border-[var(--landing-border)] bg-[var(--landing-elevated)] px-5 py-2.5 text-sm font-medium text-[var(--landing-fg)] transition-colors hover:bg-[var(--landing-band)] disabled:opacity-50"
+          >
+            {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+            Load more
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/components/community/CommunityMapPreview.tsx
+++ b/client/components/community/CommunityMapPreview.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import mapboxgl from "mapbox-gl";
+import "mapbox-gl/dist/mapbox-gl.css";
+import type { CustomRoute } from "@/lib/gtfs";
+
+interface CommunityMapPreviewProps {
+  route: CustomRoute;
+  className?: string;
+}
+
+export default function CommunityMapPreview({ route, className = "" }: CommunityMapPreviewProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<mapboxgl.Map | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const token = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
+    if (!token) return;
+    mapboxgl.accessToken = token;
+
+    // Build coordinate list from geometry or stops
+    const coords: [number, number][] =
+      Array.isArray(route.geometry) && route.geometry.length > 1
+        ? route.geometry
+        : (route.stops ?? []).map((s) => [s.lon, s.lat]);
+
+    if (coords.length === 0) return;
+
+    // Compute bounding box
+    const lons = coords.map(([lon]) => lon);
+    const lats = coords.map(([, lat]) => lat);
+    const bounds = new mapboxgl.LngLatBounds(
+      [Math.min(...lons), Math.min(...lats)],
+      [Math.max(...lons), Math.max(...lats)]
+    );
+
+    const map = new mapboxgl.Map({
+      container: containerRef.current,
+      style: "mapbox://styles/mapbox/streets-v12",
+      bounds,
+      fitBoundsOptions: { padding: 48, maxZoom: 14 },
+      interactive: false,
+      attributionControl: false,
+    });
+    mapRef.current = map;
+
+    map.on("load", () => {
+      // Route line
+      map.addSource("route", {
+        type: "geojson",
+        data: {
+          type: "Feature",
+          geometry: { type: "LineString", coordinates: coords },
+          properties: {},
+        },
+      });
+
+      map.addLayer({
+        id: "route-line-casing",
+        type: "line",
+        source: "route",
+        layout: { "line-cap": "round", "line-join": "round" },
+        paint: {
+          "line-color": "#ffffff",
+          "line-width": 6,
+          "line-opacity": 0.8,
+        },
+      });
+
+      map.addLayer({
+        id: "route-line",
+        type: "line",
+        source: "route",
+        layout: { "line-cap": "round", "line-join": "round" },
+        paint: {
+          "line-color": route.color ?? "#3b82f6",
+          "line-width": 4,
+        },
+      });
+
+      // Stops
+      const stops = route.stops ?? [];
+      if (stops.length > 0) {
+        map.addSource("stops", {
+          type: "geojson",
+          data: {
+            type: "FeatureCollection",
+            features: stops.map((s, i) => ({
+              type: "Feature",
+              geometry: { type: "Point", coordinates: [s.lon, s.lat] },
+              properties: { name: s.name ?? "", isEndpoint: i === 0 || i === stops.length - 1 },
+            })),
+          },
+        });
+
+        // All stops: white dot with coloured border
+        map.addLayer({
+          id: "stops-circle",
+          type: "circle",
+          source: "stops",
+          paint: {
+            "circle-radius": ["case", ["get", "isEndpoint"], 7, 5],
+            "circle-color": "#ffffff",
+            "circle-stroke-color": route.color ?? "#3b82f6",
+            "circle-stroke-width": 2.5,
+          },
+        });
+
+        // Stop name labels
+        map.addLayer({
+          id: "stops-label",
+          type: "symbol",
+          source: "stops",
+          layout: {
+            "text-field": ["get", "name"],
+            "text-size": 11,
+            "text-offset": [0, 1.2],
+            "text-anchor": "top",
+            "text-max-width": 10,
+          },
+          paint: {
+            "text-color": "#1e293b",
+            "text-halo-color": "#ffffff",
+            "text-halo-width": 1.5,
+          },
+        });
+      }
+    });
+
+    return () => {
+      map.remove();
+      mapRef.current = null;
+    };
+  }, [route]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={`h-72 w-full rounded-2xl overflow-hidden ${className}`}
+      aria-label={`Map preview for ${route.name}`}
+    />
+  );
+}

--- a/client/components/community/CommunityMapPreviewWrapper.tsx
+++ b/client/components/community/CommunityMapPreviewWrapper.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { CustomRoute } from "@/lib/gtfs";
+
+const CommunityMapPreview = dynamic(
+  () => import("@/components/community/CommunityMapPreview"),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-72 w-full animate-pulse rounded-2xl bg-slate-100" />
+    ),
+  }
+);
+
+export default function CommunityMapPreviewWrapper({ route }: { route: CustomRoute }) {
+  return <CommunityMapPreview route={route} />;
+}

--- a/client/components/community/LikeButton.tsx
+++ b/client/components/community/LikeButton.tsx
@@ -29,7 +29,7 @@ export default function LikeButton({ postId, initialLikesCount }: LikeButtonProp
 
   const handleToggle = async () => {
     if (status === "unauthenticated") {
-      signIn("github");
+      signIn();
       return;
     }
     if (loading) return;

--- a/client/components/community/LikeButton.tsx
+++ b/client/components/community/LikeButton.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useSession } from "next-auth/react";
+import { Heart } from "lucide-react";
+import { signIn } from "next-auth/react";
+
+interface LikeButtonProps {
+  postId: string;
+  initialLikesCount: number;
+}
+
+export default function LikeButton({ postId, initialLikesCount }: LikeButtonProps) {
+  const { data: session, status } = useSession();
+  const [liked, setLiked] = useState(false);
+  const [likesCount, setLikesCount] = useState(initialLikesCount);
+  const [loading, setLoading] = useState(false);
+
+  // Fetch initial liked state for the current user
+  useEffect(() => {
+    if (status !== "authenticated") return;
+    fetch(`/api/community/posts/${postId}/likes`)
+      .then((r) => r.json())
+      .then((data: { liked?: boolean }) => {
+        if (typeof data.liked === "boolean") setLiked(data.liked);
+      })
+      .catch(() => {/* silent */});
+  }, [postId, status]);
+
+  const handleToggle = async () => {
+    if (status === "unauthenticated") {
+      signIn("github");
+      return;
+    }
+    if (loading) return;
+    setLoading(true);
+
+    // Optimistic update
+    const wasLiked = liked;
+    setLiked(!wasLiked);
+    setLikesCount((c) => c + (wasLiked ? -1 : 1));
+
+    try {
+      const res = await fetch(`/api/community/posts/${postId}/likes`, {
+        method: "POST",
+      });
+      const data = (await res.json()) as { liked?: boolean; likesCount?: number };
+      if (typeof data.liked === "boolean") setLiked(data.liked);
+      if (typeof data.likesCount === "number") setLikesCount(data.likesCount);
+    } catch {
+      // Revert optimistic update on error
+      setLiked(wasLiked);
+      setLikesCount((c) => c + (wasLiked ? 1 : -1));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleToggle}
+      disabled={loading || status === "loading"}
+      aria-label={liked ? "Unlike this route" : "Like this route"}
+      className={`inline-flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-all disabled:opacity-50 ${
+        liked
+          ? "border-red-200 bg-red-50 text-red-600 hover:bg-red-100"
+          : "border-[var(--landing-border)] bg-[var(--landing-elevated)] text-[var(--landing-muted)] hover:text-[var(--landing-fg)]"
+      }`}
+    >
+      <Heart
+        className={`h-4 w-4 transition-transform ${liked ? "fill-red-500 stroke-red-500 scale-110" : ""}`}
+        aria-hidden
+      />
+      {likesCount} {likesCount === 1 ? "like" : "likes"}
+    </button>
+  );
+}

--- a/client/components/community/MiniRouteMap.tsx
+++ b/client/components/community/MiniRouteMap.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import type { CustomRoute, CustomStop } from "@/lib/gtfs";
+
+interface MiniRouteMapProps {
+  route: CustomRoute;
+  className?: string;
+}
+
+function projectStops(stops: CustomStop[], width: number, height: number) {
+  if (stops.length === 0) return [];
+  const lons = stops.map((s) => s.lon);
+  const lats = stops.map((s) => s.lat);
+  const minLon = Math.min(...lons);
+  const maxLon = Math.max(...lons);
+  const minLat = Math.min(...lats);
+  const maxLat = Math.max(...lats);
+
+  const pad = 12;
+  const rangeX = maxLon - minLon || 0.01;
+  const rangeY = maxLat - minLat || 0.01;
+
+  return stops.map((s) => ({
+    x: pad + ((s.lon - minLon) / rangeX) * (width - pad * 2),
+    // Flip Y: higher lat = higher on screen
+    y: height - pad - ((s.lat - minLat) / rangeY) * (height - pad * 2),
+    name: s.name,
+  }));
+}
+
+function projectGeometry(
+  geometry: [number, number][],
+  width: number,
+  height: number
+) {
+  if (geometry.length === 0) return "";
+  const lons = geometry.map(([lon]) => lon);
+  const lats = geometry.map(([, lat]) => lat);
+  const minLon = Math.min(...lons);
+  const maxLon = Math.max(...lons);
+  const minLat = Math.min(...lats);
+  const maxLat = Math.max(...lats);
+
+  const pad = 12;
+  const rangeX = maxLon - minLon || 0.01;
+  const rangeY = maxLat - minLat || 0.01;
+
+  return geometry
+    .map(([lon, lat], i) => {
+      const x = pad + ((lon - minLon) / rangeX) * (width - pad * 2);
+      const y = height - pad - ((lat - minLat) / rangeY) * (height - pad * 2);
+      return `${i === 0 ? "M" : "L"} ${x.toFixed(1)} ${y.toFixed(1)}`;
+    })
+    .join(" ");
+}
+
+export default function MiniRouteMap({ route, className = "" }: MiniRouteMapProps) {
+  const W = 280;
+  const H = 160;
+  const color = route.color ?? "#3b82f6";
+
+  const hasGeometry = Array.isArray(route.geometry) && route.geometry.length > 1;
+  const hasStops = Array.isArray(route.stops) && route.stops.length > 0;
+
+  if (!hasGeometry && !hasStops) {
+    return (
+      <div
+        className={`flex items-center justify-center rounded-xl bg-[var(--landing-band)] text-xs text-[var(--landing-muted)] ${className}`}
+        style={{ height: H }}
+      >
+        No geometry
+      </div>
+    );
+  }
+
+  const pathD = hasGeometry
+    ? projectGeometry(route.geometry!, W, H)
+    : "";
+
+  const projectedStops = hasStops ? projectStops(route.stops, W, H) : [];
+
+  // If no geometry but stops exist, draw a polyline through stop positions
+  const stopPolyline =
+    !hasGeometry && projectedStops.length > 1
+      ? projectedStops
+          .map((p, i) => `${i === 0 ? "M" : "L"} ${p.x.toFixed(1)} ${p.y.toFixed(1)}`)
+          .join(" ")
+      : "";
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      width="100%"
+      height={H}
+      className={`rounded-xl bg-[var(--landing-band)] ${className}`}
+      aria-label={`Map preview for ${route.name}`}
+      role="img"
+    >
+      {/* Route line */}
+      {(pathD || stopPolyline) && (
+        <path
+          d={pathD || stopPolyline}
+          stroke={color}
+          strokeWidth={2.5}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          fill="none"
+          opacity={0.85}
+        />
+      )}
+
+      {/* Stop dots */}
+      {projectedStops.map((p, i) => (
+        <circle
+          key={i}
+          cx={p.x}
+          cy={p.y}
+          r={i === 0 || i === projectedStops.length - 1 ? 4 : 2.5}
+          fill={color}
+          stroke="white"
+          strokeWidth={1}
+          opacity={0.9}
+        />
+      ))}
+    </svg>
+  );
+}

--- a/client/components/community/PostCard.tsx
+++ b/client/components/community/PostCard.tsx
@@ -1,0 +1,78 @@
+import Link from "next/link";
+import { Heart, MapPin } from "lucide-react";
+import AuthorAvatar from "./AuthorAvatar";
+import RouteTypeBadge from "./RouteTypeBadge";
+
+export interface PostSummary {
+  id: string;
+  title: string;
+  description: string | null;
+  stopCount: number;
+  routeType: string;
+  color: string;
+  likesCount: number;
+  createdAt: Date | string;
+  user: {
+    id: string;
+    name: string | null;
+    avatarUrl: string | null;
+    githubLogin: string | null;
+  };
+}
+
+interface PostCardProps {
+  post: PostSummary;
+}
+
+export default function PostCard({ post }: PostCardProps) {
+  const date = new Date(post.createdAt).toLocaleDateString("en-CA", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+
+  return (
+    <Link
+      href={`/community/${post.id}`}
+      className="group flex flex-col gap-3 rounded-2xl border border-[var(--landing-border)] bg-[var(--landing-elevated)] p-5 shadow-[0_4px_24px_-12px_color-mix(in_oklab,var(--landing-fg)_12%,transparent)] transition-[border-color,box-shadow,transform] hover:-translate-y-0.5 hover:border-[color-mix(in_oklab,var(--landing-fg)_14%,var(--landing-border))] hover:shadow-[0_8px_32px_-12px_color-mix(in_oklab,var(--landing-fg)_18%,transparent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--landing-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--landing-bg)]"
+    >
+      {/* Color strip */}
+      <div className="h-1 w-full rounded-full" style={{ backgroundColor: post.color }} />
+
+      {/* Title + type */}
+      <div className="flex items-start justify-between gap-2">
+        <h3 className="line-clamp-2 text-base font-semibold text-[var(--landing-fg)] leading-snug">
+          {post.title}
+        </h3>
+        <RouteTypeBadge type={post.routeType} />
+      </div>
+
+      {/* Description */}
+      {post.description && (
+        <p className="line-clamp-2 text-sm leading-relaxed text-[var(--landing-muted)]">
+          {post.description}
+        </p>
+      )}
+
+      {/* Meta row */}
+      <div className="mt-auto flex items-center justify-between gap-2 pt-1">
+        <AuthorAvatar
+          name={post.user.name}
+          avatarUrl={post.user.avatarUrl}
+          githubLogin={post.user.githubLogin}
+        />
+        <div className="flex items-center gap-3 text-xs text-[var(--landing-muted)]">
+          <span className="flex items-center gap-1">
+            <MapPin className="h-3 w-3" aria-hidden />
+            {post.stopCount} stop{post.stopCount !== 1 ? "s" : ""}
+          </span>
+          <span className="flex items-center gap-1">
+            <Heart className="h-3 w-3" aria-hidden />
+            {post.likesCount}
+          </span>
+          <span>{date}</span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/client/components/community/PostCard.tsx
+++ b/client/components/community/PostCard.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 import { Heart, MapPin } from "lucide-react";
 import AuthorAvatar from "./AuthorAvatar";
 import RouteTypeBadge from "./RouteTypeBadge";
@@ -12,6 +13,7 @@ export interface PostSummary {
   color: string;
   likesCount: number;
   createdAt: Date | string;
+  previewUrl: string | null;
   user: {
     id: string;
     name: string | null;
@@ -26,51 +28,82 @@ interface PostCardProps {
 
 export default function PostCard({ post }: PostCardProps) {
   const date = new Date(post.createdAt).toLocaleDateString("en-CA", {
-    year: "numeric",
     month: "short",
     day: "numeric",
+    year: "numeric",
   });
 
   return (
     <Link
       href={`/community/${post.id}`}
-      className="group flex flex-col gap-3 rounded-2xl border border-[var(--landing-border)] bg-[var(--landing-elevated)] p-5 shadow-[0_4px_24px_-12px_color-mix(in_oklab,var(--landing-fg)_12%,transparent)] transition-[border-color,box-shadow,transform] hover:-translate-y-0.5 hover:border-[color-mix(in_oklab,var(--landing-fg)_14%,var(--landing-border))] hover:shadow-[0_8px_32px_-12px_color-mix(in_oklab,var(--landing-fg)_18%,transparent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--landing-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--landing-bg)]"
+      className="group flex flex-col overflow-hidden rounded-2xl border border-[var(--landing-border)] bg-[var(--landing-elevated)] shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--landing-accent)] focus-visible:ring-offset-2"
     >
-      {/* Color strip */}
-      <div className="h-1 w-full rounded-full" style={{ backgroundColor: post.color }} />
+      {/* Map preview */}
+      <div className="relative h-44 w-full overflow-hidden bg-slate-100">
+        {post.previewUrl ? (
+          <Image
+            src={post.previewUrl}
+            alt={`Map preview for ${post.title}`}
+            fill
+            sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+            className="object-cover transition-transform duration-300 group-hover:scale-105"
+            unoptimized
+          />
+        ) : (
+          /* Fallback: coloured gradient when no image */
+          <div
+            className="absolute inset-0"
+            style={{
+              background: `linear-gradient(135deg, ${post.color}22 0%, ${post.color}44 100%)`,
+            }}
+          />
+        )}
 
-      {/* Title + type */}
-      <div className="flex items-start justify-between gap-2">
-        <h3 className="line-clamp-2 text-base font-semibold text-[var(--landing-fg)] leading-snug">
-          {post.title}
-        </h3>
-        <RouteTypeBadge type={post.routeType} />
+        {/* Bottom fade */}
+        <div className="absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-white/90 to-transparent" />
+
+        {/* Type badge pinned top-right */}
+        <div className="absolute right-3 top-3">
+          <RouteTypeBadge type={post.routeType} />
+        </div>
+
+        {/* Colour accent bar at bottom of image */}
+        <div
+          className="absolute inset-x-0 bottom-0 h-0.5"
+          style={{ backgroundColor: post.color }}
+        />
       </div>
 
-      {/* Description */}
-      {post.description && (
-        <p className="line-clamp-2 text-sm leading-relaxed text-[var(--landing-muted)]">
-          {post.description}
-        </p>
-      )}
+      {/* Card body */}
+      <div className="flex flex-1 flex-col gap-2 p-4">
+        <h3 className="line-clamp-2 text-base font-semibold leading-snug text-[var(--landing-fg)] group-hover:text-[var(--landing-accent)] transition-colors">
+          {post.title}
+        </h3>
 
-      {/* Meta row */}
-      <div className="mt-auto flex items-center justify-between gap-2 pt-1">
-        <AuthorAvatar
-          name={post.user.name}
-          avatarUrl={post.user.avatarUrl}
-          githubLogin={post.user.githubLogin}
-        />
-        <div className="flex items-center gap-3 text-xs text-[var(--landing-muted)]">
-          <span className="flex items-center gap-1">
-            <MapPin className="h-3 w-3" aria-hidden />
-            {post.stopCount} stop{post.stopCount !== 1 ? "s" : ""}
-          </span>
-          <span className="flex items-center gap-1">
-            <Heart className="h-3 w-3" aria-hidden />
-            {post.likesCount}
-          </span>
-          <span>{date}</span>
+        {post.description && (
+          <p className="line-clamp-2 text-xs leading-relaxed text-[var(--landing-muted)]">
+            {post.description}
+          </p>
+        )}
+
+        {/* Meta row */}
+        <div className="mt-auto flex items-center justify-between gap-2 pt-2">
+          <AuthorAvatar
+            name={post.user.name}
+            avatarUrl={post.user.avatarUrl}
+            githubLogin={post.user.githubLogin}
+          />
+          <div className="flex items-center gap-2.5 text-[11px] text-[var(--landing-muted)]">
+            <span className="flex items-center gap-1">
+              <MapPin className="h-3 w-3" aria-hidden />
+              {post.stopCount}
+            </span>
+            <span className="flex items-center gap-1">
+              <Heart className="h-3 w-3" aria-hidden />
+              {post.likesCount}
+            </span>
+            <span>{date}</span>
+          </div>
         </div>
       </div>
     </Link>

--- a/client/components/community/RouteTypeBadge.tsx
+++ b/client/components/community/RouteTypeBadge.tsx
@@ -1,0 +1,21 @@
+import { Bus, Train } from "lucide-react";
+
+interface RouteTypeBadgeProps {
+  type: string;
+}
+
+export default function RouteTypeBadge({ type }: RouteTypeBadgeProps) {
+  const isTrain = type === "train";
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold ${
+        isTrain
+          ? "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
+          : "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300"
+      }`}
+    >
+      {isTrain ? <Train className="h-3 w-3" aria-hidden /> : <Bus className="h-3 w-3" aria-hidden />}
+      {isTrain ? "Train" : "Bus"}
+    </span>
+  );
+}

--- a/client/components/community/ShareModal.tsx
+++ b/client/components/community/ShareModal.tsx
@@ -80,15 +80,30 @@ export default function ShareModal({ route, onClose }: ShareModalProps) {
 
         {/* Not signed in */}
         {status !== "authenticated" ? (
-          <div className="flex flex-col items-center gap-4 py-6 text-center">
+          <div className="flex flex-col items-center gap-3 py-6 text-center">
             <p className="text-sm text-[var(--landing-muted)]">
-              Sign in with GitHub to share your route.
+              Sign in to share your route with the community.
             </p>
             <button
               onClick={() => signIn("github")}
-              className="inline-flex items-center gap-2 rounded-lg bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-slate-700"
+              className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-slate-700"
             >
-              Sign in with GitHub
+              <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+                <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+              </svg>
+              Continue with GitHub
+            </button>
+            <button
+              onClick={() => signIn("google")}
+              className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-slate-200 bg-white px-5 py-2.5 text-sm font-semibold text-slate-800 transition-colors hover:bg-slate-50"
+            >
+              <svg className="h-4 w-4" viewBox="0 0 24 24" aria-hidden>
+                <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
+                <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+                <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z" fill="#FBBC05"/>
+                <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+              </svg>
+              Continue with Google
             </button>
           </div>
         ) : (

--- a/client/components/community/ShareModal.tsx
+++ b/client/components/community/ShareModal.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useSession, signIn } from "next-auth/react";
+import { Loader2, Share2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import type { CustomRoute } from "@/lib/gtfs";
+
+interface ShareModalProps {
+  route: CustomRoute | null;
+  onClose: () => void;
+}
+
+export default function ShareModal({ route, onClose }: ShareModalProps) {
+  const router = useRouter();
+  const { data: session, status } = useSession();
+  const [title, setTitle] = useState(route?.name ?? "");
+  const [description, setDescription] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Sync title when route changes
+  if (route && title === "" && route.name) {
+    setTitle(route.name);
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!route || submitting) return;
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/community/posts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: title.trim(), description: description.trim(), routeData: route }),
+      });
+      const data = (await res.json()) as { post?: { id: string }; error?: string };
+
+      if (res.status === 401) {
+        // Shouldn't reach here since we gate below, but handle anyway
+        signIn("github");
+        return;
+      }
+      if (!res.ok) {
+        setError(data.error ?? "Something went wrong");
+        return;
+      }
+      onClose();
+      router.push(`/community/${data.post!.id}`);
+    } catch {
+      setError("Network error — please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const isOpen = !!route;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <div className="flex items-center gap-2">
+            <Share2 className="h-5 w-5 text-[var(--landing-accent)]" aria-hidden />
+            <DialogTitle>Share to community</DialogTitle>
+          </div>
+          <DialogDescription>
+            Post your route publicly so others can browse and load it into their map.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Not signed in */}
+        {status !== "authenticated" ? (
+          <div className="flex flex-col items-center gap-4 py-6 text-center">
+            <p className="text-sm text-[var(--landing-muted)]">
+              Sign in with GitHub to share your route.
+            </p>
+            <button
+              onClick={() => signIn("github")}
+              className="inline-flex items-center gap-2 rounded-lg bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-slate-700"
+            >
+              Sign in with GitHub
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="flex flex-col gap-4 pt-2">
+            <div className="flex flex-col gap-1.5">
+              <label htmlFor="share-title" className="text-sm font-medium text-[var(--landing-fg)]">
+                Title <span className="text-red-500">*</span>
+              </label>
+              <input
+                id="share-title"
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                maxLength={120}
+                required
+                placeholder={route?.name ?? "My route"}
+                className="rounded-lg border border-[var(--landing-border)] bg-[var(--landing-bg)] px-3 py-2 text-sm text-[var(--landing-fg)] outline-none placeholder:text-[var(--landing-muted)] focus:border-[var(--landing-accent)] focus:ring-1 focus:ring-[var(--landing-accent)]"
+              />
+              <p className="text-right text-xs text-[var(--landing-muted)]">
+                {title.length}/120
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <label htmlFor="share-desc" className="text-sm font-medium text-[var(--landing-fg)]">
+                Description
+              </label>
+              <textarea
+                id="share-desc"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                maxLength={1000}
+                rows={3}
+                placeholder="What makes this route interesting?"
+                className="resize-none rounded-lg border border-[var(--landing-border)] bg-[var(--landing-bg)] px-3 py-2 text-sm text-[var(--landing-fg)] outline-none placeholder:text-[var(--landing-muted)] focus:border-[var(--landing-accent)] focus:ring-1 focus:ring-[var(--landing-accent)]"
+              />
+            </div>
+
+            {error && (
+              <p className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-600">
+                {error}
+              </p>
+            )}
+
+            <div className="flex justify-end gap-2 pt-1">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-lg border border-[var(--landing-border)] px-4 py-2 text-sm font-medium text-[var(--landing-muted)] transition-colors hover:text-[var(--landing-fg)]"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={submitting || !title.trim()}
+                className="inline-flex items-center gap-2 rounded-lg bg-[var(--landing-accent)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#006b2d] disabled:opacity-50"
+              >
+                {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+                Share
+              </button>
+            </div>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/components/marketing/MarketingHeader.tsx
+++ b/client/components/marketing/MarketingHeader.tsx
@@ -5,9 +5,6 @@ const MAP = "/map";
 
 const NAV = [
   { label: "Explore", href: MAP },
-  { label: "Design", href: MAP },
-  { label: "Schedules", href: MAP },
-  { label: "Simulate", href: MAP },
   { label: "Community", href: "/community" },
   { label: "About", href: "/about" },
 ] as const;

--- a/client/components/marketing/MarketingHeader.tsx
+++ b/client/components/marketing/MarketingHeader.tsx
@@ -8,6 +8,7 @@ const NAV = [
   { label: "Design", href: MAP },
   { label: "Schedules", href: MAP },
   { label: "Simulate", href: MAP },
+  { label: "Community", href: "/community" },
   { label: "About", href: "/about" },
 ] as const;
 

--- a/client/components/overlays/RouteInfoCard.tsx
+++ b/client/components/overlays/RouteInfoCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { X, Train, Bus, ArrowRight, MapPin, Trash2 } from "lucide-react";
+import { X, Train, Bus, ArrowRight, MapPin, Trash2, Share2 } from "lucide-react";
 import { colorForRoute, GO_RAIL_LINES } from "@/lib/routeColors";
 
 interface RouteInfoCardProps {
@@ -17,6 +17,7 @@ interface RouteInfoCardProps {
   deleteLabel?: string;
   placement?: "bottom-center" | "top-left";
   onDelete?: () => void;
+  onShare?: () => void;
   onClose: () => void;
   onExplore: () => void;
 }
@@ -35,6 +36,7 @@ export default function RouteInfoCard({
   deleteLabel = "Delete route",
   placement = "bottom-center",
   onDelete,
+  onShare,
   onClose,
   onExplore,
 }: RouteInfoCardProps) {
@@ -102,6 +104,16 @@ export default function RouteInfoCard({
           >
             {actionLabel} <ArrowRight className="w-3.5 h-3.5" />
           </button>
+
+          {onShare && (
+            <button
+              onClick={onShare}
+              className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg border border-slate-200 bg-slate-50 py-2 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-100"
+            >
+              <Share2 className="h-3.5 w-3.5" />
+              Share to community
+            </button>
+          )}
 
           {onDelete && (
             <button

--- a/client/components/panels/BrowsePanel.tsx
+++ b/client/components/panels/BrowsePanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Bus, ChevronDown, ChevronUp, Pencil, Search, Train, Trash2 } from "lucide-react";
+import { Bus, ChevronDown, ChevronUp, Pencil, Search, Share2, Train, Trash2 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { GO_RAIL_LINES } from "@/lib/routeColors";
@@ -14,6 +14,7 @@ interface BrowsePanelProps {
   routeFilters: RouteFilters;
   onRouteFilterChange: (filters: RouteFilters) => void;
   onDeleteCustomRoute: (routeId: string, routeName: string) => void;
+  onShareCustomRoute: (routeId: string) => void;
 }
 
 function matchesSearch(route: EnrichedRoute, lineName: string | undefined, q: string) {
@@ -50,6 +51,7 @@ export default function BrowsePanel({
   routeFilters,
   onRouteFilterChange,
   onDeleteCustomRoute,
+  onShareCustomRoute,
 }: BrowsePanelProps) {
   const [routes, setRoutes] = useState<EnrichedRoute[]>([]);
   const [loading, setLoading] = useState(true);
@@ -416,6 +418,18 @@ export default function BrowsePanel({
                         <span className="min-w-0 flex-1 truncate text-xs font-medium text-slate-900">
                           {route.name || "Custom route"}
                         </span>
+                      </button>
+                      <button
+                        type="button"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onShareCustomRoute(route.id);
+                        }}
+                        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-slate-400 transition-colors hover:bg-emerald-50 hover:text-emerald-600"
+                        aria-label={`Share ${route.name || "custom route"} to community`}
+                        title="Share to community"
+                      >
+                        <Share2 className="h-3 w-3" />
                       </button>
                       <button
                         type="button"

--- a/client/components/panels/SimulationHUD.tsx
+++ b/client/components/panels/SimulationHUD.tsx
@@ -18,6 +18,7 @@ interface SimulationHUDProps {
   speed: 1 | 10 | 60;
   loading: boolean;
   error: string | null;
+  hasEverLoaded: boolean;
   selectedRoutes: string[];
   customRoutes: CustomRoute[];
   date: string;
@@ -83,6 +84,7 @@ export default function SimulationHUD({
   speed,
   loading,
   error,
+  hasEverLoaded,
   selectedRoutes,
   customRoutes,
   date,
@@ -117,7 +119,7 @@ export default function SimulationHUD({
 
   // ── Onboarding / empty state ──────────────────────────────────────────────
   // Distinguish "never started" from "started but no service on this date"
-  const hasLoadedOnce = startTime !== endTime || error !== null;
+  const hasLoadedOnce = hasEverLoaded;
 
   if (!hasTrips && !loading) {
     const noServiceOnDate = hasLoadedOnce && !error;

--- a/client/drizzle.config.ts
+++ b/client/drizzle.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  schema: "./lib/db/schema.ts",
+  out: "./drizzle",
+  dialect: "postgresql",
+  dbCredentials: {
+    url: process.env.DATABASE_URL!,
+  },
+});

--- a/client/hooks/useSimulation.ts
+++ b/client/hooks/useSimulation.ts
@@ -48,6 +48,9 @@ export function useSimulation(customRoutes: CustomRoute[] = []) {
   // Pre-computed shape caches keyed by trip_id — built once when trips load
   const shapeCachesRef = useRef<Map<string, ShapeCache>>(new Map());
 
+  // Tracks whether the user has ever clicked "Start simulation" this session
+  const hasEverLoadedRef = useRef<boolean>(false);
+
   const rafRef = useRef<number | null>(null);
   const lastTimestampRef = useRef<number | null>(null);
 
@@ -90,6 +93,7 @@ export function useSimulation(customRoutes: CustomRoute[] = []) {
   const clearSimulation = useCallback(() => {
     if (rafRef.current) cancelAnimationFrame(rafRef.current);
     shapeCachesRef.current.clear();
+    hasEverLoadedRef.current = false;
     setState((prev) => ({
       ...prev,
       trips: [],
@@ -120,6 +124,7 @@ export function useSimulation(customRoutes: CustomRoute[] = []) {
         .filter((id): id is string => id !== null);
       const goRoutes = routes.filter((route) => getCustomRouteIdFromSelection(route) === null);
 
+      hasEverLoadedRef.current = true;
       setState((prev) => ({ ...prev, loading: true, error: null, playing: false, trips: [] }));
       shapeCachesRef.current.clear();
 
@@ -188,6 +193,7 @@ export function useSimulation(customRoutes: CustomRoute[] = []) {
     selectedRoutes,
     date,
     startHour,
+    hasEverLoaded: hasEverLoadedRef.current,
     activeVehicles,
     setSelectedRoutes,
     setDate,

--- a/client/lib/auth.ts
+++ b/client/lib/auth.ts
@@ -1,11 +1,16 @@
 import NextAuth from "next-auth";
 import GitHub from "next-auth/providers/github";
+import Google from "next-auth/providers/google";
 
 export const { auth, handlers, signIn, signOut } = NextAuth({
   providers: [
     GitHub({
       clientId: process.env.AUTH_GITHUB_ID!,
       clientSecret: process.env.AUTH_GITHUB_SECRET!,
+    }),
+    Google({
+      clientId: process.env.AUTH_GOOGLE_ID!,
+      clientSecret: process.env.AUTH_GOOGLE_SECRET!,
     }),
   ],
   session: { strategy: "jwt" },

--- a/client/lib/auth.ts
+++ b/client/lib/auth.ts
@@ -1,0 +1,32 @@
+import NextAuth from "next-auth";
+import GitHub from "next-auth/providers/github";
+
+export const { auth, handlers, signIn, signOut } = NextAuth({
+  providers: [
+    GitHub({
+      clientId: process.env.AUTH_GITHUB_ID!,
+      clientSecret: process.env.AUTH_GITHUB_SECRET!,
+    }),
+  ],
+  session: { strategy: "jwt" },
+  callbacks: {
+    jwt({ token, profile }) {
+      // Persist GitHub login handle and avatar into the JWT on first sign-in
+      if (profile) {
+        const p = profile as { login?: string; avatar_url?: string };
+        if (p.login) token.login = p.login;
+        if (p.avatar_url) token.picture = p.avatar_url;
+      }
+      return token;
+    },
+    session({ session, token }) {
+      if (session.user) {
+        // Expose the GitHub user id (stable, globally unique) as session.user.id
+        session.user.id = token.sub!;
+        (session.user as typeof session.user & { login?: string }).login =
+          token.login as string | undefined;
+      }
+      return session;
+    },
+  },
+});

--- a/client/lib/db/index.ts
+++ b/client/lib/db/index.ts
@@ -1,0 +1,33 @@
+import { neon } from "@neondatabase/serverless";
+import { drizzle, type NeonHttpDatabase } from "drizzle-orm/neon-http";
+import * as schema from "./schema";
+
+type Schema = typeof schema;
+
+let _db: NeonHttpDatabase<Schema> | null = null;
+
+function getDb(): NeonHttpDatabase<Schema> {
+  if (!_db) {
+    const connectionString = process.env.DATABASE_URL;
+    if (!connectionString) {
+      throw new Error(
+        "DATABASE_URL is not set. Add it to .env.local and to Vercel environment variables."
+      );
+    }
+    const sql = neon(connectionString);
+    _db = drizzle(sql, { schema });
+  }
+  return _db;
+}
+
+/**
+ * Lazy Drizzle client — only connects to Neon on the first actual DB call.
+ * Safe to import at module level without DATABASE_URL set at build time.
+ */
+export const db = new Proxy({} as NeonHttpDatabase<Schema>, {
+  get(_target, prop) {
+    return (getDb() as unknown as Record<string | symbol, unknown>)[prop];
+  },
+});
+
+export * from "./schema";

--- a/client/lib/db/schema.ts
+++ b/client/lib/db/schema.ts
@@ -1,0 +1,71 @@
+import {
+  pgTable,
+  text,
+  uuid,
+  timestamp,
+  integer,
+  jsonb,
+  primaryKey,
+} from "drizzle-orm/pg-core";
+
+// ── Users ──────────────────────────────────────────────────────────────────
+// Synced from JWT on first write (post, like, comment).
+export const users = pgTable("community_users", {
+  id: text("id").primaryKey(),            // GitHub numeric user id (JWT sub)
+  name: text("name"),
+  avatarUrl: text("avatar_url"),
+  githubLogin: text("github_login"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+// ── Posts ──────────────────────────────────────────────────────────────────
+export const posts = pgTable("community_posts", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  title: text("title").notNull(),
+  description: text("description"),
+  routeData: jsonb("route_data").notNull(),  // serialized CustomRoute
+  stopCount: integer("stop_count").notNull().default(0),
+  routeType: text("route_type").notNull(),   // "bus" | "train"
+  color: text("color").notNull(),
+  likesCount: integer("likes_count").notNull().default(0),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+// ── Likes ──────────────────────────────────────────────────────────────────
+export const likes = pgTable(
+  "community_likes",
+  {
+    postId: uuid("post_id")
+      .notNull()
+      .references(() => posts.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [primaryKey({ columns: [table.postId, table.userId] })]
+);
+
+// ── Comments ──────────────────────────────────────────────────────────────
+export const comments = pgTable("community_comments", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  postId: uuid("post_id")
+    .notNull()
+    .references(() => posts.id, { onDelete: "cascade" }),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  body: text("body").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+// ── Type exports ──────────────────────────────────────────────────────────
+export type User = typeof users.$inferSelect;
+export type Post = typeof posts.$inferSelect;
+export type Like = typeof likes.$inferSelect;
+export type Comment = typeof comments.$inferSelect;
+export type NewPost = typeof posts.$inferInsert;
+export type NewComment = typeof comments.$inferInsert;

--- a/client/lib/mapboxStaticImage.ts
+++ b/client/lib/mapboxStaticImage.ts
@@ -1,0 +1,73 @@
+import type { CustomRoute } from "@/lib/gtfs";
+
+/** Reduce an array to at most `maxPts` evenly-sampled points. */
+function simplify<T>(arr: T[], maxPts: number): T[] {
+  if (arr.length <= maxPts) return arr;
+  const step = (arr.length - 1) / (maxPts - 1);
+  return Array.from({ length: maxPts }, (_, i) => arr[Math.round(i * step)]);
+}
+
+/**
+ * Returns a Mapbox Static Images API URL that renders the route as a
+ * coloured line on a streets basemap, or null if the token is missing.
+ *
+ * Safe to call server-side; uses NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN which is
+ * already public and safe to embed in URLs returned to the client.
+ */
+export function buildStaticMapUrl(
+  route: CustomRoute,
+  width = 600,
+  height = 280
+): string | null {
+  const token = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
+  if (!token) return null;
+
+  const color = route.color ?? "#3b82f6";
+
+  // Prefer drawn geometry; fall back to stop positions
+  const rawCoords: [number, number][] =
+    Array.isArray(route.geometry) && route.geometry.length > 1
+      ? route.geometry
+      : (route.stops ?? []).map((s) => [s.lon, s.lat] as [number, number]);
+
+  if (rawCoords.length < 2) return null;
+
+  const coords = simplify(rawCoords, 30);
+
+  // Strip "#" from hex — Mapbox uses bare hex in GeoJSON properties
+  const hexColor = color.startsWith("#") ? color.slice(1) : color;
+
+  const geojson = JSON.stringify({
+    type: "FeatureCollection",
+    features: [
+      // Route line with casing
+      {
+        type: "Feature",
+        properties: {
+          stroke: "ffffff",
+          "stroke-width": 7,
+          "stroke-opacity": 0.7,
+        },
+        geometry: { type: "LineString", coordinates: coords },
+      },
+      // Route line
+      {
+        type: "Feature",
+        properties: {
+          stroke: hexColor,
+          "stroke-width": 4,
+          "stroke-opacity": 1,
+        },
+        geometry: { type: "LineString", coordinates: coords },
+      },
+    ],
+  });
+
+  const overlay = `geojson(${encodeURIComponent(geojson)})`;
+  const size = `${width}x${height}@2x`;
+
+  return (
+    `https://api.mapbox.com/styles/v1/mapbox/streets-v12/static/` +
+    `${overlay}/auto/${size}?padding=40,40,40,40&access_token=${token}`
+  );
+}

--- a/client/lib/mapboxStaticImage.ts
+++ b/client/lib/mapboxStaticImage.ts
@@ -9,10 +9,9 @@ function simplify<T>(arr: T[], maxPts: number): T[] {
 
 /**
  * Returns a Mapbox Static Images API URL that renders the route as a
- * coloured line on a streets basemap, or null if the token is missing.
+ * coloured line + stop markers on a streets basemap.
  *
- * Safe to call server-side; uses NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN which is
- * already public and safe to embed in URLs returned to the client.
+ * Uses NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN — already public, safe in URLs.
  */
 export function buildStaticMapUrl(
   route: CustomRoute,
@@ -22,9 +21,14 @@ export function buildStaticMapUrl(
   const token = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
   if (!token) return null;
 
-  const color = route.color ?? "#3b82f6";
+  // Ensure color is a valid 6-char hex (simplestyle needs it without #)
+  const rawColor = route.color ?? "#3b82f6";
+  const hex = (rawColor.startsWith("#") ? rawColor.slice(1) : rawColor)
+    .replace(/[^0-9a-fA-F]/g, "")
+    .padEnd(6, "0")
+    .slice(0, 6);
 
-  // Prefer drawn geometry; fall back to stop positions
+  // Prefer drawn geometry; fall back to stop lat/lon order
   const rawCoords: [number, number][] =
     Array.isArray(route.geometry) && route.geometry.length > 1
       ? route.geometry
@@ -32,42 +36,60 @@ export function buildStaticMapUrl(
 
   if (rawCoords.length < 2) return null;
 
-  const coords = simplify(rawCoords, 30);
+  const coords = simplify(rawCoords, 25);
+  const stops = route.stops ?? [];
 
-  // Strip "#" from hex — Mapbox uses bare hex in GeoJSON properties
-  const hexColor = color.startsWith("#") ? color.slice(1) : color;
+  const color = `#${hex}`;
 
-  const geojson = JSON.stringify({
-    type: "FeatureCollection",
-    features: [
-      // Route line with casing
-      {
+  const features: object[] = [
+    // White casing so the line is legible on any background
+    {
+      type: "Feature",
+      properties: { stroke: "#ffffff", "stroke-width": 8, "stroke-opacity": 0.9 },
+      geometry: { type: "LineString", coordinates: coords },
+    },
+    // Coloured route line
+    {
+      type: "Feature",
+      properties: { stroke: color, "stroke-width": 5, "stroke-opacity": 1 },
+      geometry: { type: "LineString", coordinates: coords },
+    },
+    // Intermediate stop dots
+    ...stops.slice(1, -1).map((s) => ({
+      type: "Feature",
+      properties: {
+        "marker-color": "#ffffff",
+        "marker-size": "small",
+        stroke: color,
+        "stroke-width": 2,
+        fill: "#ffffff",
+        "fill-opacity": 1,
+      },
+      geometry: { type: "Point", coordinates: [s.lon, s.lat] },
+    })),
+    // Endpoint circles (coloured fill)
+    ...[stops[0], stops.length > 1 ? stops[stops.length - 1] : null]
+      .filter(Boolean)
+      .map((s) => ({
         type: "Feature",
         properties: {
-          stroke: "ffffff",
-          "stroke-width": 7,
-          "stroke-opacity": 0.7,
+          "marker-color": color,
+          "marker-size": "medium",
+          stroke: "#ffffff",
+          "stroke-width": 2,
+          fill: color,
+          "fill-opacity": 1,
         },
-        geometry: { type: "LineString", coordinates: coords },
-      },
-      // Route line
-      {
-        type: "Feature",
-        properties: {
-          stroke: hexColor,
-          "stroke-width": 4,
-          "stroke-opacity": 1,
-        },
-        geometry: { type: "LineString", coordinates: coords },
-      },
-    ],
-  });
+        geometry: { type: "Point", coordinates: [s!.lon, s!.lat] },
+      })),
+  ];
 
+  const geojson = JSON.stringify({ type: "FeatureCollection", features });
   const overlay = `geojson(${encodeURIComponent(geojson)})`;
   const size = `${width}x${height}@2x`;
 
   return (
     `https://api.mapbox.com/styles/v1/mapbox/streets-v12/static/` +
-    `${overlay}/auto/${size}?padding=40,40,40,40&access_token=${token}`
+    `${overlay}/auto/${size}?padding=50,50,50,50&access_token=${token}`
   );
 }

--- a/client/lib/upsertUser.ts
+++ b/client/lib/upsertUser.ts
@@ -1,0 +1,34 @@
+import type { Session } from "next-auth";
+import { db, users } from "@/lib/db";
+import { eq } from "drizzle-orm";
+
+type SessionUser = Session["user"] & { login?: string };
+
+/**
+ * Syncs the authenticated user into the community_users table.
+ * Called at the start of every write handler (post, like, comment).
+ */
+export async function upsertUser(session: Session): Promise<void> {
+  const user = session.user as SessionUser;
+  if (!user?.id) return;
+
+  await db
+    .insert(users)
+    .values({
+      id: user.id,
+      name: user.name ?? null,
+      avatarUrl: user.image ?? null,
+      githubLogin: user.login ?? null,
+    })
+    .onConflictDoUpdate({
+      target: users.id,
+      set: {
+        name: user.name ?? null,
+        avatarUrl: user.image ?? null,
+        githubLogin: user.login ?? null,
+      },
+    });
+}
+
+// Re-export for convenience
+export { eq };

--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -1,7 +1,13 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      { protocol: "https", hostname: "api.mapbox.com" },
+      { protocol: "https", hostname: "avatars.githubusercontent.com" },
+      { protocol: "https", hostname: "lh3.googleusercontent.com" },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,15 +8,19 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@auth/core": "^0.41.2",
         "@base-ui/react": "^1.4.0",
         "@mapbox/mapbox-gl-draw": "^1.5.1",
+        "@neondatabase/serverless": "^1.1.0",
         "@types/mapbox-gl": "^3.4.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "drizzle-orm": "^0.45.2",
         "framer-motion": "^12.38.0",
         "lucide-react": "^1.8.0",
         "mapbox-gl": "^3.22.0",
         "next": "16.2.4",
+        "next-auth": "^5.0.0-beta.31",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "shadcn": "^4.3.0",
@@ -33,6 +37,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/uuid": "^10.0.0",
+        "drizzle-kit": "^0.31.10",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -48,6 +53,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@auth/core": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.2.tgz",
+      "integrity": "sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^7.0.7"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -683,6 +717,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/@drizzle-team/brocli": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@drizzle-team/brocli/-/brocli-0.10.2.tgz",
+      "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@ecies/ciphers": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.6.tgz",
@@ -705,6 +746,884 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.3.2.tgz",
+      "integrity": "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==",
+      "deprecated": "Merged into tsx: https://tsx.is",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.18.20",
+        "source-map-support": "^0.5.21"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "node_modules/@esbuild-kit/esm-loader": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.6.5.tgz",
+      "integrity": "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==",
+      "deprecated": "Merged into tsx: https://tsx.is",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@esbuild-kit/core-utils": "^3.3.2",
+        "get-tsconfig": "^4.7.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -1501,6 +2420,15 @@
       "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
       "license": "MIT"
     },
+    "node_modules/@neondatabase/serverless": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.1.0.tgz",
+      "integrity": "sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=19.0.0"
+      }
+    },
     "node_modules/@next/env": {
       "version": "16.2.4",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
@@ -1730,6 +2658,15 @@
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "license": "MIT"
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/@playwright/test": {
       "version": "1.59.1",
@@ -2422,6 +3359,13 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -2962,6 +3906,147 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/drizzle-kit": {
+      "version": "0.31.10",
+      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.10.tgz",
+      "integrity": "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@drizzle-team/brocli": "^0.10.2",
+        "@esbuild-kit/esm-loader": "^2.5.5",
+        "esbuild": "^0.25.4",
+        "tsx": "^4.21.0"
+      },
+      "bin": {
+        "drizzle-kit": "bin.cjs"
+      }
+    },
+    "node_modules/drizzle-orm": {
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.2.tgz",
+      "integrity": "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/client-rds-data": ">=3",
+        "@cloudflare/workers-types": ">=4",
+        "@electric-sql/pglite": ">=0.2.0",
+        "@libsql/client": ">=0.10.0",
+        "@libsql/client-wasm": ">=0.10.0",
+        "@neondatabase/serverless": ">=0.10.0",
+        "@op-engineering/op-sqlite": ">=2",
+        "@opentelemetry/api": "^1.4.1",
+        "@planetscale/database": ">=1.13",
+        "@prisma/client": "*",
+        "@tidbcloud/serverless": "*",
+        "@types/better-sqlite3": "*",
+        "@types/pg": "*",
+        "@types/sql.js": "*",
+        "@upstash/redis": ">=1.34.7",
+        "@vercel/postgres": ">=0.8.0",
+        "@xata.io/client": "*",
+        "better-sqlite3": ">=7",
+        "bun-types": "*",
+        "expo-sqlite": ">=14.0.0",
+        "gel": ">=2",
+        "knex": "*",
+        "kysely": "*",
+        "mysql2": ">=2",
+        "pg": ">=8",
+        "postgres": ">=3",
+        "sql.js": ">=1",
+        "sqlite3": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-rds-data": {
+          "optional": true
+        },
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "@libsql/client-wasm": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
+          "optional": true
+        },
+        "@op-engineering/op-sqlite": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@tidbcloud/serverless": {
+          "optional": true
+        },
+        "@types/better-sqlite3": {
+          "optional": true
+        },
+        "@types/pg": {
+          "optional": true
+        },
+        "@types/sql.js": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/postgres": {
+          "optional": true
+        },
+        "@xata.io/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "bun-types": {
+          "optional": true
+        },
+        "expo-sqlite": {
+          "optional": true
+        },
+        "gel": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3086,6 +4171,48 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/escalade": {
@@ -3592,6 +4719,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/gl-matrix": {
@@ -4784,6 +5924,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "5.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.31.tgz",
+      "integrity": "sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.2"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
+        "nodemailer": "^7.0.7",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -4882,6 +6049,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/object-assign": {
@@ -5201,6 +6377,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
+      }
+    },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
@@ -5390,6 +6585,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/resolve-protobuf-schema": {
@@ -5811,6 +7016,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/splaytree": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-0.1.4.tgz",
@@ -6081,6 +7297,524 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.0.tgz",
+      "integrity": "sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",

--- a/client/package.json
+++ b/client/package.json
@@ -11,15 +11,19 @@
     "start": "next start"
   },
   "dependencies": {
+    "@auth/core": "^0.41.2",
     "@base-ui/react": "^1.4.0",
     "@mapbox/mapbox-gl-draw": "^1.5.1",
+    "@neondatabase/serverless": "^1.1.0",
     "@types/mapbox-gl": "^3.4.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "drizzle-orm": "^0.45.2",
     "framer-motion": "^12.38.0",
     "lucide-react": "^1.8.0",
     "mapbox-gl": "^3.22.0",
     "next": "16.2.4",
+    "next-auth": "^5.0.0-beta.31",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "shadcn": "^4.3.0",
@@ -36,6 +40,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/uuid": "^10.0.0",
+    "drizzle-kit": "^0.31.10",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/client/proxy.ts
+++ b/client/proxy.ts
@@ -1,0 +1,24 @@
+import { auth } from "@/lib/auth";
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export async function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const method = request.method ?? "GET";
+
+  const isWrite = method !== "GET";
+  const isCommunityApi = pathname.startsWith("/api/community");
+
+  if (isCommunityApi && isWrite) {
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const proxyConfig = {
+  matcher: ["/api/community/:path*"],
+};


### PR DESCRIPTION
## Summary

- **Community forum pages** (`/community`, `/community/[id]`) — public feed of shared routes with sort by recent/top, individual post detail page with Mapbox map preview, likes, and comments
- **GitHub + Google OAuth** via NextAuth v5 — JWT sessions, users upserted into Neon Postgres on first write
- **Neon Postgres + Drizzle ORM** — 4 tables: `community_users`, `community_posts`, `community_likes`, `community_comments`; lazy Proxy DB client avoids build-time `DATABASE_URL` requirement
- **Share flow** — floating Share button on map (route picker popover when multiple routes saved); share icon per route in Browse → Custom tab; ShareModal gates behind auth
- **Load into map** — `?community_route=<id>` URL param imports a community route into localStorage and removes itself
- **Mapbox Static Images** — real map preview rendered server-side as a plain `<img>` on each feed card (no extra JS); post detail page uses full interactive Mapbox GL map
- **Simulation config step** — removed auto-load; shows date/time/route picker before starting simulation
- **Nav simplification** — marketing header trimmed to Explore, Community, About

## Infrastructure

- Neon Postgres project `transit-flow` provisioned (`aws-us-east-2`)
- 4 Vercel env vars added to production: `AUTH_SECRET`, `AUTH_GITHUB_ID`, `AUTH_GITHUB_SECRET`, `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`, `DATABASE_URL`
- `api.mapbox.com`, `avatars.githubusercontent.com`, `lh3.googleusercontent.com` added to `next/image` remote patterns

## Test plan

- [ ] Visit `/community` in incognito — posts visible, no 401 errors
- [ ] Sign in with GitHub and Google — user row appears in `community_users`
- [ ] Draw a route in the map → Share → post appears on `/community/<uuid>`
- [ ] Click "Load into map" on a post → route imported, URL param removed
- [ ] Like toggle: count +1 / -1; check `community_posts.likes_count`
- [ ] Post a comment signed in; sign out → form replaced with sign-in prompt
- [ ] `curl -X POST /api/community/posts` without session → 401
- [ ] Click Simulate → config step shown (date, time, routes) before loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)