### PR TITLE
feat: integrate Metrolinx Open Data API for live service alerts

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,11 @@
+.next
+node_modules
+data
+generated
+dist
+build
+coverage
+public/gtfs
+*.csv
+*.json
+*.geojson

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vercel
 .gstack/
+node_modules/

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+npx --no -- commitlint --edit "$1"

--- a/client/app/api/metrolinx/alerts/route.ts
+++ b/client/app/api/metrolinx/alerts/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { getServiceAlerts } from "@/lib/metrolinx";
+
+/**
+ * GET /api/metrolinx/alerts
+ *
+ * Returns raw service alerts from the Metrolinx Open Data API.
+ * Cached for 5 minutes. Use /api/service-updates for the normalized
+ * version with line filtering and type classification.
+ */
+export async function GET() {
+  if (!process.env.METROLINX_API_KEY) {
+    return NextResponse.json(
+      { error: "Metrolinx API key not configured" },
+      { status: 503 }
+    );
+  }
+
+  try {
+    const data = await getServiceAlerts();
+    return NextResponse.json(data, {
+      headers: {
+        "Cache-Control": "public, s-maxage=300, stale-while-revalidate=60",
+      },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    console.error("[metrolinx/alerts]", message);
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/client/app/api/metrolinx/departures/route.ts
+++ b/client/app/api/metrolinx/departures/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getStopDepartures, getNextService } from "@/lib/metrolinx";
+
+/**
+ * GET /api/metrolinx/departures?stop=<stopCode>&mode=departures|next
+ *
+ * Proxies the Metrolinx Open Data API for stop departure data.
+ * Keeps the API key server-side; returns clean JSON to the client.
+ */
+export async function GET(request: NextRequest) {
+  const stopCode = request.nextUrl.searchParams.get("stop")?.trim();
+  const mode = request.nextUrl.searchParams.get("mode") ?? "departures";
+
+  if (!stopCode) {
+    return NextResponse.json(
+      { error: "stop query param required (e.g. ?stop=UN)" },
+      { status: 400 }
+    );
+  }
+
+  if (!process.env.METROLINX_API_KEY) {
+    return NextResponse.json(
+      { error: "Metrolinx API key not configured" },
+      { status: 503 }
+    );
+  }
+
+  try {
+    const data =
+      mode === "next"
+        ? await getNextService(stopCode)
+        : await getStopDepartures(stopCode);
+
+    return NextResponse.json(data, {
+      headers: {
+        "Cache-Control": "public, s-maxage=60, stale-while-revalidate=30",
+      },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    console.error("[metrolinx/departures]", message);
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -18,22 +18,18 @@ export const metadata: Metadata = {
     type: "website",
   },
 };
+import { ArrowRight, Check, Minus, X } from "lucide-react";
 import {
-  ArrowRight,
-  Check,
-  Minus,
-  X,
-  Route,
-  PenLine,
-  BarChart2,
-  Bell,
-  PlayCircle,
-  Layers,
-  GraduationCap,
-  Users,
-  Code2,
-  Building2,
-} from "lucide-react";
+  MAP,
+  METRICS,
+  FEATURES,
+  STEPS,
+  CAPABILITIES,
+  USE_CASES,
+  COMPARISON_FEATURES,
+  COMPARISON_DATA,
+  type CellVal,
+} from "@/constants";
 import MarketingShell from "@/components/marketing/MarketingShell";
 import LandingHeader from "@/components/marketing/LandingHeader";
 import MarketingFooter from "@/components/marketing/MarketingFooter";
@@ -46,143 +42,6 @@ import {
   MetricStrip,
   MetricItem,
 } from "@/components/marketing/LandingAnimations";
-
-const MAP = "/map";
-
-// ─── Data ────────────────────────────────────────────────────────────────────
-
-const METRICS = [
-  { value: "45+",     label: "GO Transit routes"     },
-  { value: "Live",    label: "GTFS-based routing"     },
-  { value: "4",       label: "Planning modes"         },
-  { value: "250+",    label: "Route variants"         },
-  { value: "Browser", label: "No install required"    },
-] as const;
-
-const FEATURES = [
-  {
-    icon: Route,
-    title: "Route Explorer",
-    body: "All 45 GO lines on a live map. Real stop sequences, headways, and GTFS trip data.",
-  },
-  {
-    icon: BarChart2,
-    title: "Schedule Comparison",
-    body: "Inspect timetables, compare headways across lines, and identify service gaps.",
-  },
-  {
-    icon: Bell,
-    title: "Service Updates",
-    body: "Live alerts from GO Transit — delays, cancellations, and notices, filterable by line.",
-  },
-  {
-    icon: PlayCircle,
-    title: "Simulation HUD",
-    body: "Animate the entire network or a single custom route. Scrub through any hour of the day.",
-  },
-] as const;
-
-const STEPS = [
-  {
-    n: "01",
-    title: "Connect GTFS data",
-    body: "The full GO Transit network loads instantly — stops, trips, shapes, and frequencies — derived from the live GTFS feed.",
-  },
-  {
-    n: "02",
-    title: "Explore routes visually",
-    body: "Browse any of the 45+ routes on an interactive map. Click a line to inspect its stops, trip count, and corridor.",
-  },
-  {
-    n: "03",
-    title: "Compare service patterns",
-    body: "Switch to Schedules mode to compare headways across lines or examine departure times at any stop.",
-  },
-  {
-    n: "04",
-    title: "Simulate network changes",
-    body: "Draw a new route, set its schedule, then watch it run alongside the live GO network in the simulation engine.",
-  },
-] as const;
-
-const CAPABILITIES = [
-  {
-    icon: Route,
-    title: "GTFS-powered route intelligence",
-    body: "Derived GeoJSON and stop data from the official GO Transit GTFS feed. Always accurate, always structured.",
-  },
-  {
-    icon: PenLine,
-    title: "Interactive route sketching",
-    body: "Draw corridors on the map, snap to the rail network, place stops, and wire up a full schedule in minutes.",
-  },
-  {
-    icon: BarChart2,
-    title: "Schedule and departure analysis",
-    body: "Inspect any line's timetable, compare peak vs. off-peak headways, and surface gaps in coverage.",
-  },
-  {
-    icon: Bell,
-    title: "Service update visualization",
-    body: "Live GO Transit alerts delivered directly into the workspace — filterable by line, categorized by severity.",
-  },
-  {
-    icon: PlayCircle,
-    title: "Simulation-ready transit data",
-    body: "The simulation engine animates vehicles across the real network — or any custom route you design.",
-  },
-  {
-    icon: Layers,
-    title: "Planner-friendly map workspace",
-    body: "One browser tab. Four modes. No GIS software, no install, no account required to start exploring.",
-  },
-] as const;
-
-const USE_CASES = [
-  {
-    icon: Building2,
-    tag: "For transit planners",
-    title: "Evaluate service changes before they ship.",
-    body: "Sketch a new route, compare it against the existing network, run a simulation, and share the result — all in one workspace.",
-  },
-  {
-    icon: GraduationCap,
-    tag: "For students & researchers",
-    title: "Study real networks with real data.",
-    body: "The full GO Transit GTFS feed, structured and queryable. Ideal for urban planning coursework, network analysis, and thesis research.",
-  },
-  {
-    icon: Code2,
-    tag: "For civic hackers",
-    title: "Build on live GTFS without the overhead.",
-    body: "Pre-processed GeoJSON, derived stop data, and a simulation engine — open source and ready to extend.",
-  },
-  {
-    icon: Users,
-    tag: "For agencies exploring changes",
-    title: "Communicate proposals visually.",
-    body: "Generate shareable map views of proposed service changes. Show the community what a new route looks like before a single dollar is spent.",
-  },
-] as const;
-
-const COMPARISON_FEATURES = [
-  "Live network data",
-  "Route design tools",
-  "Schedule analysis",
-  "Simulation engine",
-  "Service update alerts",
-  "Browser-based",
-  "Free to use",
-];
-
-type CellVal = "yes" | "no" | "partial";
-
-const COMPARISON_DATA: Record<string, CellVal[]> = {
-  "TransitFlow":            ["yes", "yes", "yes", "yes", "yes", "yes", "yes"],
-  "Static PDF maps":        ["no",  "no",  "no",  "no",  "no",  "partial", "yes"],
-  "Spreadsheet planning":   ["no",  "partial", "partial", "no", "no", "yes", "yes"],
-  "Disconnected GIS tools": ["partial", "partial", "no", "no", "no", "no", "no"],
-};
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
 

--- a/client/app/service-updates/page.tsx
+++ b/client/app/service-updates/page.tsx
@@ -1,15 +1,16 @@
 import type { Metadata } from "next";
-import { CheckCircle, RefreshCw } from "lucide-react";
+import { CheckCircle, RefreshCw, AlertTriangle, Wifi } from "lucide-react";
 import MarketingHeader from "@/components/marketing/MarketingHeader";
 import { AlertCard } from "@/components/service-updates/AlertCard";
 import { LineFilterBar } from "@/components/service-updates/LineFilterBar";
 import { fetchServiceUpdates } from "@/lib/serviceUpdates";
+import type { ServiceUpdatesResult } from "@/lib/serviceUpdates";
 
 const SITE_URL =
   process.env.NEXT_PUBLIC_SITE_URL ?? "https://transit-flow-two.vercel.app";
 
 export const metadata: Metadata = {
-  title: "Service Updates",
+  title: "Service Updates — TransitFlow",
   description:
     "Live GO Transit service alerts — delays, cancellations, and service notices for Lakeshore West, Barrie, Kitchener, Stouffville, Richmond Hill, Milton, and UP Express lines.",
   alternates: { canonical: `${SITE_URL}/service-updates` },
@@ -33,6 +34,34 @@ function formatFetchTime(iso: string): string {
   }
 }
 
+function SourceBadge({ source }: { source: ServiceUpdatesResult["source"] }) {
+  if (source === "metrolinx-api") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2.5 py-0.5 text-xs font-medium text-emerald-700 border border-emerald-200">
+        <Wifi className="h-3 w-3" />
+        Live — Metrolinx API
+      </span>
+    );
+  }
+  if (source === "html-fallback" || source === "nextdata") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2.5 py-0.5 text-xs font-medium text-amber-700 border border-amber-200">
+        <AlertTriangle className="h-3 w-3" />
+        Scraped — gotransit.com
+      </span>
+    );
+  }
+  if (source === "error") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-red-50 px-2.5 py-0.5 text-xs font-medium text-red-600 border border-red-200">
+        <AlertTriangle className="h-3 w-3" />
+        Source unavailable
+      </span>
+    );
+  }
+  return null;
+}
+
 export default async function ServiceUpdatesPage({
   searchParams,
 }: {
@@ -45,6 +74,9 @@ export default async function ServiceUpdatesPage({
     ? alerts.filter((a) => a.routes.includes(line.toUpperCase()))
     : alerts;
 
+  const delayCount = alerts.filter((a) => a.type === "delay").length;
+  const cancelCount = alerts.filter((a) => a.type === "cancellation").length;
+
   return (
     <div className="min-h-screen bg-white">
       <MarketingHeader />
@@ -52,24 +84,44 @@ export default async function ServiceUpdatesPage({
       <main className="mx-auto max-w-3xl px-5 pb-24 pt-14 lg:px-8">
         {/* Page header */}
         <div className="mb-10">
-          <h1 className="text-3xl font-bold tracking-tight text-gray-900">
-            Service Updates
-          </h1>
-          <p className="mt-2 text-sm text-gray-500">
-            Live GO Transit alerts — delays, cancellations, and service notices.
-          </p>
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+                Service Updates
+              </h1>
+              <p className="mt-1.5 text-sm text-gray-500">
+                Real-time GO Transit alerts — delays, cancellations, and service notices.
+              </p>
+            </div>
+            <SourceBadge source={source} />
+          </div>
+
+          {/* Stats row */}
+          {alerts.length > 0 && (
+            <div className="mt-5 flex flex-wrap gap-3">
+              <div className="rounded-xl border border-gray-100 bg-gray-50 px-4 py-2.5 text-center">
+                <p className="text-2xl font-bold text-gray-900">{alerts.length}</p>
+                <p className="text-xs text-gray-500">Active alert{alerts.length !== 1 ? "s" : ""}</p>
+              </div>
+              {delayCount > 0 && (
+                <div className="rounded-xl border border-red-100 bg-red-50 px-4 py-2.5 text-center">
+                  <p className="text-2xl font-bold text-red-600">{delayCount}</p>
+                  <p className="text-xs text-red-500">Delay{delayCount !== 1 ? "s" : ""}</p>
+                </div>
+              )}
+              {cancelCount > 0 && (
+                <div className="rounded-xl border border-red-100 bg-red-50 px-4 py-2.5 text-center">
+                  <p className="text-2xl font-bold text-red-700">{cancelCount}</p>
+                  <p className="text-xs text-red-600">Cancellation{cancelCount !== 1 ? "s" : ""}</p>
+                </div>
+              )}
+            </div>
+          )}
 
           {/* Last refreshed */}
-          <div className="mt-3 inline-flex items-center gap-1.5 text-xs text-gray-400">
+          <div className="mt-4 inline-flex items-center gap-1.5 text-xs text-gray-400">
             <RefreshCw className="h-3 w-3" />
-            <span>
-              Updated at {formatFetchTime(fetchedAt)}
-              {source === "error" && (
-                <span className="ml-2 text-red-500">
-                  (could not reach gotransit.com)
-                </span>
-              )}
-            </span>
+            <span>Updated at {formatFetchTime(fetchedAt)} · refreshes every 5 min</span>
           </div>
         </div>
 
@@ -105,16 +157,33 @@ export default async function ServiceUpdatesPage({
 
         {/* Footer note */}
         <p className="mt-12 text-center text-xs text-gray-400">
-          Data sourced from{" "}
-          <a
-            href="https://www.gotransit.com/en/service-updates"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline hover:text-gray-600 transition-colors"
-          >
-            gotransit.com
-          </a>
-          . Refreshes every 5 minutes.
+          {source === "metrolinx-api" ? (
+            <>
+              Powered by the{" "}
+              <a
+                href="https://api.openmetrolinx.com/OpenDataAPI/Help/Index/en"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline transition-colors hover:text-gray-600"
+              >
+                Metrolinx Open Data API
+              </a>
+              . Refreshes every 5 minutes.
+            </>
+          ) : (
+            <>
+              Data sourced from{" "}
+              <a
+                href="https://www.gotransit.com/en/service-updates"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline transition-colors hover:text-gray-600"
+              >
+                gotransit.com
+              </a>
+              . Refreshes every 5 minutes.
+            </>
+          )}
         </p>
       </main>
     </div>

--- a/client/components/marketing/LandingHeader.tsx
+++ b/client/components/marketing/LandingHeader.tsx
@@ -9,6 +9,7 @@ const NAV = [
   { label: "Use Cases", href: "#use-cases"      },
   { label: "Simulation",href: `${MAP}?mode=simulate` },
   { label: "Data",      href: "#capabilities"   },
+  { label: "Community", href: "/community"      },
   { label: "Roadmap",   href: "https://github.com/faizm10/transit-flow/issues" },
 ];
 

--- a/client/components/service-updates/AlertCard.tsx
+++ b/client/components/service-updates/AlertCard.tsx
@@ -1,7 +1,10 @@
+"use client";
+
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight, ChevronDown, ChevronUp } from "lucide-react";
 import { GO_RAIL_LINES } from "@/lib/routeColors";
 import type { ServiceAlert, AlertType } from "@/lib/serviceUpdates";
+import { useState } from "react";
 
 function formatDate(iso: string): string {
   try {
@@ -17,25 +20,66 @@ function formatDate(iso: string): string {
   }
 }
 
-function severityStyle(type: AlertType): { bg: string; text: string; dot: string; label: string } {
+function severityStyle(type: AlertType): {
+  bg: string;
+  text: string;
+  dot: string;
+  label: string;
+  border: string;
+} {
   switch (type) {
     case "delay":
-      return { bg: "bg-red-50", text: "text-red-600", dot: "bg-red-500", label: "Delay" };
+      return {
+        bg: "bg-red-50",
+        text: "text-red-600",
+        dot: "bg-red-500",
+        label: "Delay",
+        border: "border-red-100",
+      };
     case "cancellation":
-      return { bg: "bg-red-50", text: "text-red-700", dot: "bg-red-600", label: "Cancelled" };
+      return {
+        bg: "bg-red-50",
+        text: "text-red-700",
+        dot: "bg-red-600",
+        label: "Cancelled",
+        border: "border-red-200",
+      };
     case "information":
-      return { bg: "bg-amber-50", text: "text-amber-700", dot: "bg-amber-500", label: "Notice" };
+      return {
+        bg: "bg-amber-50",
+        text: "text-amber-700",
+        dot: "bg-amber-500",
+        label: "Notice",
+        border: "border-amber-100",
+      };
     default:
-      return { bg: "bg-gray-100", text: "text-gray-600", dot: "bg-gray-400", label: "Update" };
+      return {
+        bg: "bg-gray-100",
+        text: "text-gray-600",
+        dot: "bg-gray-400",
+        label: "Update",
+        border: "border-gray-100",
+      };
   }
 }
+
+const BODY_CLAMP_LENGTH = 220;
 
 export function AlertCard({ alert }: { alert: ServiceAlert }) {
   const sev = severityStyle(alert.type);
   const mapRoute = alert.routes[0];
+  const isLong = alert.body.length > BODY_CLAMP_LENGTH;
+  const [expanded, setExpanded] = useState(false);
+
+  const displayBody =
+    isLong && !expanded
+      ? alert.body.slice(0, BODY_CLAMP_LENGTH).trimEnd() + "…"
+      : alert.body;
 
   return (
-    <article className="rounded-2xl border border-gray-200 bg-white p-5 flex flex-col gap-3 shadow-sm">
+    <article
+      className={`rounded-2xl border bg-white p-5 flex flex-col gap-3 shadow-sm ${sev.border}`}
+    >
       {/* Top row: badges + time */}
       <div className="flex flex-wrap items-center gap-2">
         {/* Route badges */}
@@ -54,14 +98,19 @@ export function AlertCard({ alert }: { alert: ServiceAlert }) {
         })}
 
         {/* Severity badge */}
-        <span className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${sev.bg} ${sev.text}`}>
+        <span
+          className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${sev.bg} ${sev.text}`}
+        >
           <span className={`h-1.5 w-1.5 rounded-full ${sev.dot}`} />
           {sev.label}
         </span>
 
         {/* Time */}
         {alert.postedAt && (
-          <time dateTime={alert.postedAt} className="ml-auto text-xs text-gray-400 shrink-0">
+          <time
+            dateTime={alert.postedAt}
+            className="ml-auto text-xs text-gray-400 shrink-0"
+          >
             {formatDate(alert.postedAt)}
           </time>
         )}
@@ -74,9 +123,27 @@ export function AlertCard({ alert }: { alert: ServiceAlert }) {
 
       {/* Body */}
       {alert.body && (
-        <p className="text-sm text-gray-500 leading-relaxed line-clamp-3">
-          {alert.body}
-        </p>
+        <div>
+          <p className="text-sm text-gray-500 leading-relaxed whitespace-pre-line">
+            {displayBody}
+          </p>
+          {isLong && (
+            <button
+              onClick={() => setExpanded((e) => !e)}
+              className="mt-1.5 inline-flex items-center gap-0.5 text-xs font-medium text-[#007A33] hover:text-[#005c26] transition-colors"
+            >
+              {expanded ? (
+                <>
+                  Show less <ChevronUp className="h-3.5 w-3.5" />
+                </>
+              ) : (
+                <>
+                  Read more <ChevronDown className="h-3.5 w-3.5" />
+                </>
+              )}
+            </button>
+          )}
+        </div>
       )}
 
       {/* Footer: view on map */}

--- a/client/constants.ts
+++ b/client/constants.ts
@@ -1,0 +1,148 @@
+import {
+  Route,
+  PenLine,
+  BarChart2,
+  Bell,
+  PlayCircle,
+  Layers,
+  GraduationCap,
+  Users,
+  Code2,
+  Building2,
+} from "lucide-react";
+
+/** App routes used on the marketing landing page */
+export const MAP = "/map";
+
+export const METRICS = [
+  { value: "45+", label: "GO Transit routes" },
+  { value: "Live", label: "GTFS-based routing" },
+  { value: "4", label: "Planning modes" },
+  { value: "250+", label: "Route variants" },
+  { value: "Browser", label: "No install required" },
+] as const;
+
+export const FEATURES = [
+  {
+    icon: Route,
+    title: "Route Explorer",
+    body: "All 45 GO lines on a live map. Real stop sequences, headways, and GTFS trip data.",
+  },
+  {
+    icon: BarChart2,
+    title: "Schedule Comparison",
+    body: "Inspect timetables, compare headways across lines, and identify service gaps.",
+  },
+  {
+    icon: Bell,
+    title: "Service Updates",
+    body: "Live alerts from GO Transit — delays, cancellations, and notices, filterable by line.",
+  },
+  {
+    icon: PlayCircle,
+    title: "Simulation HUD",
+    body: "Animate the entire network or a single custom route. Scrub through any hour of the day.",
+  },
+] as const;
+
+export const STEPS = [
+  {
+    n: "01",
+    title: "Connect GTFS data",
+    body: "The full GO Transit network loads instantly — stops, trips, shapes, and frequencies — derived from the live GTFS feed.",
+  },
+  {
+    n: "02",
+    title: "Explore routes visually",
+    body: "Browse any of the 45+ routes on an interactive map. Click a line to inspect its stops, trip count, and corridor.",
+  },
+  {
+    n: "03",
+    title: "Compare service patterns",
+    body: "Switch to Schedules mode to compare headways across lines or examine departure times at any stop.",
+  },
+  {
+    n: "04",
+    title: "Simulate network changes",
+    body: "Draw a new route, set its schedule, then watch it run alongside the live GO network in the simulation engine.",
+  },
+] as const;
+
+export const CAPABILITIES = [
+  {
+    icon: Route,
+    title: "GTFS-powered route intelligence",
+    body: "Derived GeoJSON and stop data from the official GO Transit GTFS feed. Always accurate, always structured.",
+  },
+  {
+    icon: PenLine,
+    title: "Interactive route sketching",
+    body: "Draw corridors on the map, snap to the rail network, place stops, and wire up a full schedule in minutes.",
+  },
+  {
+    icon: BarChart2,
+    title: "Schedule and departure analysis",
+    body: "Inspect any line's timetable, compare peak vs. off-peak headways, and surface gaps in coverage.",
+  },
+  {
+    icon: Bell,
+    title: "Service update visualization",
+    body: "Live GO Transit alerts delivered directly into the workspace — filterable by line, categorized by severity.",
+  },
+  {
+    icon: PlayCircle,
+    title: "Simulation-ready transit data",
+    body: "The simulation engine animates vehicles across the real network — or any custom route you design.",
+  },
+  {
+    icon: Layers,
+    title: "Planner-friendly map workspace",
+    body: "One browser tab. Four modes. No GIS software, no install, no account required to start exploring.",
+  },
+] as const;
+
+export const USE_CASES = [
+  {
+    icon: Building2,
+    tag: "For transit planners",
+    title: "Evaluate service changes before they ship.",
+    body: "Sketch a new route, compare it against the existing network, run a simulation, and share the result — all in one workspace.",
+  },
+  {
+    icon: GraduationCap,
+    tag: "For students & researchers",
+    title: "Study real networks with real data.",
+    body: "The full GO Transit GTFS feed, structured and queryable. Ideal for urban planning coursework, network analysis, and thesis research.",
+  },
+  {
+    icon: Code2,
+    tag: "For civic hackers",
+    title: "Build on live GTFS without the overhead.",
+    body: "Pre-processed GeoJSON, derived stop data, and a simulation engine — open source and ready to extend.",
+  },
+  {
+    icon: Users,
+    tag: "For agencies exploring changes",
+    title: "Communicate proposals visually.",
+    body: "Generate shareable map views of proposed service changes. Show the community what a new route looks like before a single dollar is spent.",
+  },
+] as const;
+
+export const COMPARISON_FEATURES = [
+  "Live network data",
+  "Route design tools",
+  "Schedule analysis",
+  "Simulation engine",
+  "Service update alerts",
+  "Browser-based",
+  "Free to use",
+] as const;
+
+export type CellVal = "yes" | "no" | "partial";
+
+export const COMPARISON_DATA: Record<string, CellVal[]> = {
+  TransitFlow: ["yes", "yes", "yes", "yes", "yes", "yes", "yes"],
+  "Static PDF maps": ["no", "no", "no", "no", "no", "partial", "yes"],
+  "Spreadsheet planning": ["no", "partial", "partial", "no", "no", "yes", "yes"],
+  "Disconnected GIS tools": ["partial", "partial", "no", "no", "no", "no", "no"],
+};

--- a/client/lib/metrolinx.ts
+++ b/client/lib/metrolinx.ts
@@ -1,0 +1,126 @@
+/**
+ * Metrolinx Open Data API client
+ * Docs: https://api.openmetrolinx.com/OpenDataAPI/Help/Index/en
+ * Auth: server-side only (METROLINX_API_KEY env var)
+ */
+
+const BASE_URL = "https://api.openmetrolinx.com/OpenDataAPI/api/V1";
+
+function apiKey(): string {
+  const key = process.env.METROLINX_API_KEY;
+  if (!key) throw new Error("METROLINX_API_KEY env var is not set");
+  return key;
+}
+
+/** Low-level fetch wrapper — adds API key header + timeout */
+async function metrolinxFetch<T>(
+  path: string,
+  opts: { revalidate?: number; tags?: string[] } = {}
+): Promise<T> {
+  const url = `${BASE_URL}${path}`;
+  const res = await fetch(url, {
+    headers: {
+      apiKey: apiKey(),
+      Accept: "application/json",
+    },
+    next: {
+      revalidate: opts.revalidate ?? 300,
+      ...(opts.tags ? { tags: opts.tags } : {}),
+    },
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Metrolinx API ${res.status} ${res.statusText} — ${url}`);
+  }
+
+  return res.json() as Promise<T>;
+}
+
+// ─── Service Alerts ────────────────────────────────────────────────────────
+
+export interface MetrolinxServiceAlert {
+  ID: string;
+  Title: string;
+  Description: string;
+  StartDate: string;
+  EndDate?: string;
+  // Lines / affected routes — shape varies between API versions
+  Lines?: Array<{ Code: string; Name: string }>;
+  Line?: string;
+  Type?: string; // "Delay", "Cancellation", "Information", etc.
+}
+
+export interface MetrolinxServiceAlertsResponse {
+  Messages?: MetrolinxServiceAlert[];
+  Alerts?: MetrolinxServiceAlert[];
+  ServiceAlerts?: MetrolinxServiceAlert[];
+}
+
+export async function getServiceAlerts(): Promise<MetrolinxServiceAlertsResponse> {
+  return metrolinxFetch<MetrolinxServiceAlertsResponse>("/ServiceAlert", {
+    revalidate: 300,
+    tags: ["service-alerts"],
+  });
+}
+
+// ─── Stop Departures ───────────────────────────────────────────────────────
+
+export interface MetrolinxDeparture {
+  VehicleNumber?: string;
+  RouteCode: string;
+  RouteName?: string;
+  ScheduledDepartureTime: string; // ISO datetime or HH:MM
+  ActualDepartureTime?: string;
+  Status?: string; // "ON_TIME", "DELAYED", "CANCELLED"
+  Destination?: string;
+  Platform?: string;
+}
+
+export interface MetrolinxStopDeparturesResponse {
+  NextService?: MetrolinxDeparture[];
+  Departures?: MetrolinxDeparture[];
+}
+
+/**
+ * Get upcoming departures for a GO stop.
+ * @param stopCode  5-digit GO stop code (e.g. "UN" for Union, "MI" for Mimico)
+ */
+export async function getStopDepartures(stopCode: string): Promise<MetrolinxStopDeparturesResponse> {
+  return metrolinxFetch<MetrolinxStopDeparturesResponse>(
+    `/Stop/Departure/${encodeURIComponent(stopCode)}`,
+    { revalidate: 60, tags: [`departures-${stopCode}`] }
+  );
+}
+
+/**
+ * Get the next scheduled service at a stop.
+ */
+export async function getNextService(stopCode: string): Promise<MetrolinxStopDeparturesResponse> {
+  return metrolinxFetch<MetrolinxStopDeparturesResponse>(
+    `/Schedule/NextService/${encodeURIComponent(stopCode)}`,
+    { revalidate: 60, tags: [`next-service-${stopCode}`] }
+  );
+}
+
+// ─── Stop Details ──────────────────────────────────────────────────────────
+
+export interface MetrolinxStop {
+  StopCode: string;
+  Name: string;
+  Latitude: number;
+  Longitude: number;
+  Routes?: Array<{ Code: string; Name: string }>;
+}
+
+export interface MetrolinxStopDetailsResponse {
+  Stops?: MetrolinxStop[];
+  Stop?: MetrolinxStop;
+}
+
+export async function getStopDetails(stopCode: string): Promise<MetrolinxStopDetailsResponse> {
+  return metrolinxFetch<MetrolinxStopDetailsResponse>(
+    `/Stop/Details/${encodeURIComponent(stopCode)}`,
+    { revalidate: 3600 }
+  );
+}

--- a/client/lib/serviceUpdates.ts
+++ b/client/lib/serviceUpdates.ts
@@ -14,7 +14,7 @@ export interface ServiceAlert {
 export interface ServiceUpdatesResult {
   alerts: ServiceAlert[];
   fetchedAt: string;
-  source: "nextdata" | "html-fallback" | "error";
+  source: "metrolinx-api" | "nextdata" | "html-fallback" | "error";
 }
 
 // ── GO Line name → short code map ─────────────────────────────────────────
@@ -263,7 +263,7 @@ function parseFromMetrolinxApi(
     };
   });
 
-  return { alerts, fetchedAt, source: "nextdata" };
+  return { alerts, fetchedAt, source: "metrolinx-api" };
 }
 
 // ── Main fetch function (cached via Next.js Data Cache) ───────────────────
@@ -281,9 +281,9 @@ export async function fetchServiceUpdates(): Promise<ServiceUpdatesResult> {
     try {
       const data = await getServiceAlerts();
       const result = parseFromMetrolinxApi(data, fetchedAt);
-      if (result) return result;
+      if (result) return { ...result, source: "metrolinx-api" as const };
       // API returned empty → no active alerts (valid)
-      return { alerts: [], fetchedAt, source: "nextdata" };
+      return { alerts: [], fetchedAt, source: "metrolinx-api" as const };
     } catch (err) {
       console.warn("[service-updates] Metrolinx API failed, falling back to scrape:", err);
     }

--- a/client/lib/serviceUpdates.ts
+++ b/client/lib/serviceUpdates.ts
@@ -209,15 +209,87 @@ function parseFromHtml(html: string, fetchedAt: string): ServiceUpdatesResult {
   return { alerts, fetchedAt, source: "html-fallback" };
 }
 
+// ── Metrolinx API parser ──────────────────────────────────────────────────
+
+import { getServiceAlerts } from "@/lib/metrolinx";
+
+function parseFromMetrolinxApi(
+  data: Awaited<ReturnType<typeof getServiceAlerts>>,
+  fetchedAt: string
+): ServiceUpdatesResult | null {
+  const rawAlerts = data.Messages ?? data.Alerts ?? data.ServiceAlerts;
+  if (!rawAlerts || rawAlerts.length === 0) return null;
+
+  const alerts: ServiceAlert[] = rawAlerts.map((raw, i) => {
+    const title = raw.Title ?? "Service Alert";
+    const body = raw.Description ?? "";
+
+    // Extract affected routes from Lines field or text
+    let routes: string[] = [];
+    if (raw.Lines && raw.Lines.length > 0) {
+      routes = raw.Lines.map((l) => l.Code?.toUpperCase().trim()).filter(
+        (c): c is string => !!c && ["BR", "KI", "LE", "LW", "MI", "RH", "ST", "UP"].includes(c)
+      );
+    }
+    if (routes.length === 0 && raw.Line) {
+      routes = extractRoutes([raw.Line]);
+    }
+    if (routes.length === 0) {
+      routes = extractRoutesFromText(`${title} ${body}`);
+    }
+
+    const type: AlertType = raw.Type
+      ? (/cancel|suspend/i.test(raw.Type) ? "cancellation"
+        : /delay|disruption/i.test(raw.Type) ? "delay"
+        : /info|notice|advisory/i.test(raw.Type) ? "information"
+        : classifyType(title, body))
+      : classifyType(title, body);
+
+    const postedAt = (() => {
+      if (raw.StartDate) {
+        const d = new Date(raw.StartDate);
+        if (!isNaN(d.getTime())) return d.toISOString();
+      }
+      return fetchedAt;
+    })();
+
+    return {
+      id: raw.ID ?? `alert-${i}`,
+      title,
+      body,
+      routes,
+      type,
+      postedAt,
+    };
+  });
+
+  return { alerts, fetchedAt, source: "nextdata" };
+}
+
 // ── Main fetch function (cached via Next.js Data Cache) ───────────────────
 //
-// Using fetch() with `next: { revalidate: 300 }` caches the raw HTTP
-// response at the Next.js Data Cache layer for 5 minutes — no experimental
-// flags required. Parsing is fast (CPU-only) and happens on each revalidation.
+// Primary: Metrolinx Open Data API (real-time, official).
+// Fallback: gotransit.com scrape (HTML / __NEXT_DATA__) when API is unavailable.
+// fetch() with `next: { revalidate: 300 }` caches at the Next.js Data Cache
+// layer for 5 minutes — no experimental flags required.
 
 export async function fetchServiceUpdates(): Promise<ServiceUpdatesResult> {
   const fetchedAt = new Date().toISOString();
 
+  // ── 1. Try the official Metrolinx API ─────────────────────────────────
+  if (process.env.METROLINX_API_KEY) {
+    try {
+      const data = await getServiceAlerts();
+      const result = parseFromMetrolinxApi(data, fetchedAt);
+      if (result) return result;
+      // API returned empty → no active alerts (valid)
+      return { alerts: [], fetchedAt, source: "nextdata" };
+    } catch (err) {
+      console.warn("[service-updates] Metrolinx API failed, falling back to scrape:", err);
+    }
+  }
+
+  // ── 2. Fallback: scrape gotransit.com ─────────────────────────────────
   try {
     const res = await fetch("https://www.gotransit.com/en/service-updates", {
       headers: {
@@ -236,17 +308,12 @@ export async function fetchServiceUpdates(): Promise<ServiceUpdatesResult> {
 
     const html = await res.text();
 
-    // Primary: extract from __NEXT_DATA__
     const nextDataResult = parseFromNextData(html, fetchedAt);
-    if (nextDataResult && nextDataResult.alerts.length > 0) {
-      return nextDataResult;
-    }
+    if (nextDataResult && nextDataResult.alerts.length > 0) return nextDataResult;
 
-    // Fallback: HTML regex parse
     const htmlResult = parseFromHtml(html, fetchedAt);
     if (htmlResult.alerts.length > 0) return htmlResult;
 
-    // No alerts found (valid — service may be running normally)
     return { alerts: [], fetchedAt, source: nextDataResult ? "nextdata" : "html-fallback" };
   } catch {
     return { alerts: [], fetchedAt, source: "error" };

--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -1,6 +1,12 @@
+import path from "path";
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  experimental: {
+    turbopack: {
+      root: path.resolve(__dirname),
+    },
+  },
   images: {
     qualities: [75, 92],
     remotePatterns: [

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,24 @@
+/** @type {import('@commitlint/types').UserConfig} */
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "bug",
+        "docs",
+        "style",
+        "refactor",
+        "perf",
+        "test",
+        "chore",
+        "build",
+        "ci",
+      ],
+    ],
+    "subject-case": [0],
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1264 @@
+{
+  "name": "transit-flow",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "transit-flow",
+      "devDependencies": {
+        "@commitlint/cli": "^19.8.0",
+        "@commitlint/config-conventional": "^19.8.0",
+        "husky": "^9.1.7"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@commitlint/cli": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.8.1.tgz",
+      "integrity": "sha512-LXUdNIkspyxrlV6VDHWBmCZRtkEVRpBKxi2Gtw3J54cGWhLCTouVD/Q6ZSaSvd2YaDObWK8mDjrz3TIKtaQMAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/format": "^19.8.1",
+        "@commitlint/lint": "^19.8.1",
+        "@commitlint/load": "^19.8.1",
+        "@commitlint/read": "^19.8.1",
+        "@commitlint/types": "^19.8.1",
+        "tinyexec": "^1.0.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "commitlint": "cli.js"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/config-conventional": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.8.1.tgz",
+      "integrity": "sha512-/AZHJL6F6B/G959CsMAzrPKKZjeEiAVifRyEwXxcT6qtqbPwGw+iQxmNS+Bu+i09OCtdNRW6pNpBvgPrtMr9EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^19.8.1",
+        "conventional-changelog-conventionalcommits": "^7.0.2"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/config-validator": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.8.1.tgz",
+      "integrity": "sha512-0jvJ4u+eqGPBIzzSdqKNX1rvdbSU1lPNYlfQQRIFnBgLy26BtC0cFnr7c/AyuzExMxWsMOte6MkTi9I3SQ3iGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^19.8.1",
+        "ajv": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/ensure": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.8.1.tgz",
+      "integrity": "sha512-mXDnlJdvDzSObafjYrOSvZBwkD01cqB4gbnnFuVyNpGUM5ijwU/r/6uqUmBXAAOKRfyEjpkGVZxaDsCVnHAgyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^19.8.1",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.snakecase": "^4.1.1",
+        "lodash.startcase": "^4.4.0",
+        "lodash.upperfirst": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/execute-rule": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.8.1.tgz",
+      "integrity": "sha512-YfJyIqIKWI64Mgvn/sE7FXvVMQER/Cd+s3hZke6cI1xgNT/f6ZAz5heND0QtffH+KbcqAwXDEE1/5niYayYaQA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/format": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-19.8.1.tgz",
+      "integrity": "sha512-kSJj34Rp10ItP+Eh9oCItiuN/HwGQMXBnIRk69jdOwEW9llW9FlyqcWYbHPSGofmjsqeoxa38UaEA5tsbm2JWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^19.8.1",
+        "chalk": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/is-ignored": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.8.1.tgz",
+      "integrity": "sha512-AceOhEhekBUQ5dzrVhDDsbMaY5LqtN8s1mqSnT2Kz1ERvVZkNihrs3Sfk1Je/rxRNbXYFzKZSHaPsEJJDJV8dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^19.8.1",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/lint": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.8.1.tgz",
+      "integrity": "sha512-52PFbsl+1EvMuokZXLRlOsdcLHf10isTPlWwoY1FQIidTsTvjKXVXYb7AvtpWkDzRO2ZsqIgPK7bI98x8LRUEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/is-ignored": "^19.8.1",
+        "@commitlint/parse": "^19.8.1",
+        "@commitlint/rules": "^19.8.1",
+        "@commitlint/types": "^19.8.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/load": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-19.8.1.tgz",
+      "integrity": "sha512-9V99EKG3u7z+FEoe4ikgq7YGRCSukAcvmKQuTtUyiYPnOd9a2/H9Ak1J9nJA1HChRQp9OA/sIKPugGS+FK/k1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-validator": "^19.8.1",
+        "@commitlint/execute-rule": "^19.8.1",
+        "@commitlint/resolve-extends": "^19.8.1",
+        "@commitlint/types": "^19.8.1",
+        "chalk": "^5.3.0",
+        "cosmiconfig": "^9.0.0",
+        "cosmiconfig-typescript-loader": "^6.1.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "lodash.uniq": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/message": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-19.8.1.tgz",
+      "integrity": "sha512-+PMLQvjRXiU+Ae0Wc+p99EoGEutzSXFVwQfa3jRNUZLNW5odZAyseb92OSBTKCu+9gGZiJASt76Cj3dLTtcTdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/parse": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-19.8.1.tgz",
+      "integrity": "sha512-mmAHYcMBmAgJDKWdkjIGq50X4yB0pSGpxyOODwYmoexxxiUCy5JJT99t1+PEMK7KtsCtzuWYIAXYAiKR+k+/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^19.8.1",
+        "conventional-changelog-angular": "^7.0.0",
+        "conventional-commits-parser": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/read": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-19.8.1.tgz",
+      "integrity": "sha512-03Jbjb1MqluaVXKHKRuGhcKWtSgh3Jizqy2lJCRbRrnWpcM06MYm8th59Xcns8EqBYvo0Xqb+2DoZFlga97uXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/top-level": "^19.8.1",
+        "@commitlint/types": "^19.8.1",
+        "git-raw-commits": "^4.0.0",
+        "minimist": "^1.2.8",
+        "tinyexec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/resolve-extends": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.8.1.tgz",
+      "integrity": "sha512-GM0mAhFk49I+T/5UCYns5ayGStkTt4XFFrjjf0L4S26xoMTSkdCf9ZRO8en1kuopC4isDFuEm7ZOm/WRVeElVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-validator": "^19.8.1",
+        "@commitlint/types": "^19.8.1",
+        "global-directory": "^4.0.1",
+        "import-meta-resolve": "^4.0.0",
+        "lodash.mergewith": "^4.6.2",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/rules": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-19.8.1.tgz",
+      "integrity": "sha512-Hnlhd9DyvGiGwjfjfToMi1dsnw1EXKGJNLTcsuGORHz6SS9swRgkBsou33MQ2n51/boIDrbsg4tIBbRpEWK2kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/ensure": "^19.8.1",
+        "@commitlint/message": "^19.8.1",
+        "@commitlint/to-lines": "^19.8.1",
+        "@commitlint/types": "^19.8.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/to-lines": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.8.1.tgz",
+      "integrity": "sha512-98Mm5inzbWTKuZQr2aW4SReY6WUukdWXuZhrqf1QdKPZBCCsXuG87c+iP0bwtD6DBnmVVQjgp4whoHRVixyPBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/top-level": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.8.1.tgz",
+      "integrity": "sha512-Ph8IN1IOHPSDhURCSXBz44+CIu+60duFwRsg6HqaISFHQHbmBtxVw4ZrFNIYUzEP7WwrNPxa2/5qJ//NK1FGcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/types": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.8.1.tgz",
+      "integrity": "sha512-/yCrWGCoA1SVKOks25EGadP9Pnj0oAIHGpl2wH2M2Y46dPM2ueb8wyCVOD7O3WCTkaJ0IkKvzhl1JY7+uCT2Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/conventional-commits-parser": "^5.0.0",
+        "chalk": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@types/conventional-commits-parser": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.2.tgz",
+      "integrity": "sha512-BgT2szDXnVypgpNxOK8aL5SGjUdaQbC++WZNjF1Qge3Og2+zhHj+RWhmehLhYyvQwqAmvezruVfOf8+3m74W+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-ify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/compare-func": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^5.1.0"
+      }
+    },
+    "node_modules/conventional-changelog-angular": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
+      "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/conventional-commits-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz",
+      "integrity": "sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-text-path": "^2.0.0",
+        "JSONStream": "^1.3.5",
+        "meow": "^12.0.1",
+        "split2": "^4.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "cli.mjs"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cosmiconfig-typescript-loader": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.3.0.tgz",
+      "integrity": "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jiti": "2.6.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "cosmiconfig": ">=9",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/dargs": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz",
+      "integrity": "sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/find-up": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-7.0.0.tgz",
+      "integrity": "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^7.2.0",
+        "path-exists": "^5.0.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/git-raw-commits": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-4.0.0.tgz",
+      "integrity": "sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==",
+      "deprecated": "This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dargs": "^8.0.0",
+        "meow": "^12.0.1",
+        "split2": "^4.0.0"
+      },
+      "bin": {
+        "git-raw-commits": "cli.mjs"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-text-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
+      "integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "text-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      },
+      "bin": {
+        "JSONStream": "bin.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.upperfirst": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
+      "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/meow": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
+      "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-extensions": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.4.0.tgz",
+      "integrity": "sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "transit-flow",
+  "private": true,
+  "scripts": {
+    "prepare": "husky"
+  },
+  "devDependencies": {
+    "@commitlint/cli": "^19.8.0",
+    "@commitlint/config-conventional": "^19.8.0",
+    "husky": "^9.1.7"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `client/lib/metrolinx.ts` — a typed API client for the Metrolinx Open Data API (service alerts, stop departures, stop details), keeping the API key server-side
- Adds two Next.js API proxy routes: `GET /api/metrolinx/alerts` and `GET /api/metrolinx/departures?stop=<code>&mode=departures|next`
- Upgrades `fetchServiceUpdates` to use the Metrolinx API as the primary source (with the existing gotransit.com HTML scrape as automatic fallback) — no downtime if the key is missing
- Adds a `SourceBadge` to the Service Updates page showing "Live — Metrolinx API" vs "Scraped — gotransit.com" vs "Source unavailable"
- Adds an at-a-glance stats row (active alerts / delays / cancellations) at the top of the page
- Upgrades `AlertCard` to severity-coloured borders and expandable "Read more / Show less" body text for long alerts

## Test plan

- [ ] Set `METROLINX_API_KEY` in `.env.local` and verify the Service Updates page shows the green "Live — Metrolinx API" badge
- [ ] Remove/unset the key and confirm the page falls back to the scrape source (amber badge) without errors
- [ ] Hit `GET /api/metrolinx/alerts` directly and confirm JSON is returned with cache headers
- [ ] Hit `GET /api/metrolinx/departures?stop=UN` and confirm departure data comes back
- [ ] Verify long alert bodies show "Read more" expand/collapse button
- [ ] Confirm alerts with no active updates render cleanly (empty state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)